### PR TITLE
fix payment method

### DIFF
--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -1009,7 +1009,7 @@ if ($resql)
 						$error++;
 						setEventMessages($objecttmp->ref.' '.$langs->trans("RequestAlreadyDone"), $objecttmp->errors, 'errors');
 					}
-					if(!empty($objecttmp->mode_reglement_id ) && $objecttmp->mode_reglement_id != 3  ){
+					if($objecttmp->mode_reglement_id != 3  ){
 						$error++;
 						setEventMessages($objecttmp->ref.' '.$langs->trans("BadPaymentMethod"), $objecttmp->errors, 'errors');
 					}


### PR DESCRIPTION
S'il n'y a pas de méthode de paiement, on affiche une erreur.