### PR TITLE
FIX: calculer correctement le reste à payer pour les écritures bancaires prévues

### DIFF
--- a/htdocs/compta/bank/treso.php
+++ b/htdocs/compta/bank/treso.php
@@ -282,6 +282,8 @@ if ($_REQUEST["account"] || $_REQUEST["ref"])
 				$refcomp=$societestatic->getNomUrl(1,'',24);
 
 				$paiement = $facturestatic->getSommePaiement();	// Payment already done
+				$paiement+= $facturestatic->getSumDepositsUsed();
+				$paiement+= $facturestatic->getSumCreditNotesUsed();
 			}
 			if ($obj->family == 'social_contribution')
 			{


### PR DESCRIPTION
Les acomptes et les avoirs ne sont pas pris en compte dans le calcul du reste à payer des écritures bancaires futures.