### PR TITLE
New show html list instead input text for extrafields typed as list

### DIFF
--- a/htdocs/core/tpl/extrafields_list_search_input.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_search_input.tpl.php
@@ -24,11 +24,11 @@ if (! empty($extrafieldsobjectkey))	// $extrafieldsobject is the $object->table_
 				$typeofextrafield=$extrafields->attributes[$extrafieldsobjectkey]['type'][$key];
 				print '<td class="liste_titre'.($align?' '.$align:'').'">';
 				$tmpkey=preg_replace('/'.$search_options_pattern.'/', '', $key);
-				if (in_array($typeofextrafield, array('varchar', 'int', 'double', 'select')) && empty($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key]))
+				if (in_array($typeofextrafield, array('varchar', 'int', 'double')) && empty($extrafields->attributes[$extrafieldsobjectkey]['computed'][$key]))
 				{
 					$crit=$val;
 					$searchclass='';
-					if (in_array($typeofextrafield, array('varchar', 'select'))) $searchclass='searchstring';
+					if (in_array($typeofextrafield, array('varchar'))) $searchclass='searchstring';
 					if (in_array($typeofextrafield, array('int', 'double'))) $searchclass='searchnum';
 					print '<input class="flat'.($searchclass?' '.$searchclass:'').'" size="4" type="text" name="'.$search_options_pattern.$tmpkey.'" value="'.dol_escape_htmltag($search_array_options[$search_options_pattern.$tmpkey]).'">';
 				}
@@ -36,8 +36,10 @@ if (! empty($extrafieldsobjectkey))	// $extrafieldsobject is the $object->table_
 				{
 					// for the type as 'checkbox', 'chkbxlst', 'sellist' we should use code instead of id (example: I declare a 'chkbxlst' to have a link with dictionnairy, I have to extend it with the 'code' instead 'rowid')
 					$morecss='';
-					if (in_array($typeofextrafield, array('link', 'sellist'))) $morecss='maxwidth200';
-					echo $extrafields->showInputField($key, $search_array_options[$search_options_pattern.$tmpkey], '', '', $search_options_pattern, $morecss);
+					if ($typeofextrafield == 'sellist') $morecss='maxwidth200';
+					$keyprefix=$search_options_pattern;
+					if (substr($search_options_pattern, -8) === 'options_') $keyprefix = substr($search_options_pattern, 0,-8);
+					echo $extrafields->showInputField($key, $search_array_options[$search_options_pattern.$tmpkey], '', '', $keyprefix, $morecss);
 				}
 				elseif (in_array($typeofextrafield, array('datetime','timestamp')))
 				{


### PR DESCRIPTION
# Fix: on list views, filter for 'select' extrafields works with a text input (code only)
On list views, the list filter shown for extrafields of type 'select' is a plain text search and it will filter only on the extrafield’s code (not on the value displayed).

This fix is a cherry-picked backport of PH's PR https://github.com/Dolibarr/dolibarr/pull/11035