### PR TITLE
manage exclude code event array in agenda export

### DIFF
--- a/htdocs/admin/agenda_xcal.php
+++ b/htdocs/admin/agenda_xcal.php
@@ -178,6 +178,7 @@ $message.=$langs->trans("AgendaUrlOptionsNotAdmin",$user->login,$user->login).'<
 $message.=$langs->trans("AgendaUrlOptions4",$user->login,$user->login).'<br>';
 $message.=$langs->trans("AgendaUrlOptionsProject",$user->login,$user->login).'<br>';
 $message.=$langs->trans("AgendaUrlOptionsNotAutoEvent",'systemauto','systemauto').'<br>';
+$message.=$langs->trans("AgendaUrlOptionsNotActionCode").'<br>';
 
 print info_admin($message);
 

--- a/htdocs/comm/action/class/actioncomm.class.php
+++ b/htdocs/comm/action/class/actioncomm.class.php
@@ -1479,6 +1479,11 @@ class ActionComm extends CommonObject
                 if ($key == 'project')      $sql.=" AND a.fk_project=".(is_numeric($value)?$value:0);
                 if ($key == 'actiontype')    $sql.=" AND c.type = '".$this->db->escape($value)."'";
                 if ($key == 'notactiontype') $sql.=" AND c.type <> '".$this->db->escape($value)."'";
+                if ($key == 'notactioncode' && is_array($value) && !empty($value)) {
+					$codeArray = array();
+					foreach ($value as $c_code) $codeArray[] = $this->db->escape($c_code);
+					$sql.=" AND c.code NOT IN ('".implode("','", $codeArray)."')";
+				}
                 // We must filter on assignement table
 				if ($key == 'logint')       $sql.= " AND ar.fk_actioncomm = a.id AND ar.element_type='user'";
                 if ($key == 'logina')

--- a/htdocs/langs/en_US/agenda.lang
+++ b/htdocs/langs/en_US/agenda.lang
@@ -110,6 +110,7 @@ AgendaUrlOptionsNotAdmin=<b>logina=!%s</b> to restrict output to actions not own
 AgendaUrlOptions4=<b>logint=%s</b> to restrict output to actions assigned to user <b>%s</b> (owner and others).
 AgendaUrlOptionsProject=<b>project=__PROJECT_ID__</b> to restrict output to actions linked to project <b>__PROJECT_ID__</b>.
 AgendaUrlOptionsNotAutoEvent=<b>notactiontype=systemauto</b> to exclude automatic events.
+AgendaUrlOptionsNotActionCode=<b>notactioncode[]=AC_TEL&notactioncode[]=AC_INT</b> to exclude Phone Calls and Intervention on site.
 AgendaShowBirthdayEvents=Show birthdays of contacts
 AgendaHideBirthdayEvents=Hide birthdays of contacts
 Busy=Busy

--- a/htdocs/public/agenda/agendaexport.php
+++ b/htdocs/public/agenda/agendaexport.php
@@ -80,6 +80,7 @@ if (GETPOST("project",'apha'))       $filters['project']=GETPOST("project",'apha
 if (GETPOST("logina",'apha'))        $filters['logina']=GETPOST("logina",'apha');
 if (GETPOST("logint",'apha'))        $filters['logint']=GETPOST("logint",'apha');
 if (GETPOST("notactiontype",'apha')) $filters['notactiontype']=GETPOST("notactiontype",'apha');
+if (GETPOST("notactioncode",'array')) $filters['notactioncode']=GETPOST("notactioncode",'array');
 if (GETPOST("actiontype",'apha'))    $filters['actiontype']=GETPOST("actiontype",'apha');
 if (GETPOST("notolderthan",'int'))   $filters['notolderthan']=GETPOST("notolderthan","int");
 else $filters['notolderthan']=$conf->global->MAIN_AGENDA_EXPORT_PAST_DELAY;


### PR DESCRIPTION
# New exclude event by type
excluding some events of the agendaexport by passing the filter "notactioncode" which is an array.

