### PR TITLE
FIX - Clone Fourn Command, add line's extrafields

### DIFF
--- a/htdocs/fourn/class/fournisseur.commande.class.php
+++ b/htdocs/fourn/class/fournisseur.commande.class.php
@@ -1288,6 +1288,10 @@ class CommandeFournisseur extends CommonOrder
 
 		$this->db->begin();
 
+        // get extrafields so they will be clone
+        foreach($this->lines as $line)
+            $line->fetch_optionals($line->rowid);
+
 		// Load source object
 		$objFrom = clone $this;
 


### PR DESCRIPTION
Prendre en compte les extrafields des lignes lors du clonage des commandes fournisseurs (même code que pour les propal)