### PR TITLE
T2197 - Nouveau bouton permettant la création de produit

### DIFF
--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -372,3 +372,5 @@ ActionAvailableOnVariantProductOnly=Action only available on the variant of prod
 ProductsPricePerCustomer=Product prices per customers
 MakeProduct=Make product
 QtyToMake=Quantity to make
+FeatureDoesntHandleLotBatch=Feature doesn't handle lot/batch/serial number
+MakingProductFromAssociatedProducts=Allow production from associated products

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -370,3 +370,5 @@ ErrorDestinationProductNotFound=Destination product not found
 ErrorProductCombinationNotFound=Product variant not found
 ActionAvailableOnVariantProductOnly=Action only available on the variant of product
 ProductsPricePerCustomer=Product prices per customers
+MakeProduct=Make product
+QtyToMake=Quantity to make

--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -213,3 +213,5 @@ StockDecrease=Stock decrease
 StockIsRequiredToChooseWhichLotToUse=Stock is required to choose which lot to use
 MakingProductFromVirtualProduct=Making product %s from virtual product
 ErrorDuringStockMovement=Error during stock movement
+ComponentWarehouses=Component Warehouses
+ManufacturedProductWarehouse=Manufactured product warehouse

--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -211,5 +211,5 @@ StockDecreaseAfterCorrectTransfer=Decrease by correction/transfer
 StockIncrease=Stock increase
 StockDecrease=Stock decrease
 StockIsRequiredToChooseWhichLotToUse=Stock is required to choose which lot to use
-MakingProduct=Making product for %s
+MakingProductFromVirtualProduct=Making product %s from virtual product
 ErrorDuringStockMovement=Error during stock movement

--- a/htdocs/langs/en_US/stocks.lang
+++ b/htdocs/langs/en_US/stocks.lang
@@ -211,3 +211,5 @@ StockDecreaseAfterCorrectTransfer=Decrease by correction/transfer
 StockIncrease=Stock increase
 StockDecrease=Stock decrease
 StockIsRequiredToChooseWhichLotToUse=Stock is required to choose which lot to use
+MakingProduct=Making product for %s
+ErrorDuringStockMovement=Error during stock movement

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -342,3 +342,5 @@ ErrorProductCombinationNotFound=Variante du produit non trouvé
 ActionAvailableOnVariantProductOnly=Action disponible uniquement sur la variante du produit
 ProductsPricePerCustomer=Prix produit par clients
 GlobalSearchOnExtrafield=Recherche globale : Appliquer la recherche sur les extrafields (Attention : les dates sont au format YYYY-MM-DD)
+MakeProduct=Fabriquer produit
+QtyToMake=Quantité à produire

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -344,3 +344,5 @@ ProductsPricePerCustomer=Prix produit par clients
 GlobalSearchOnExtrafield=Recherche globale : Appliquer la recherche sur les extrafields (Attention : les dates sont au format YYYY-MM-DD)
 MakeProduct=Fabriquer produit
 QtyToMake=Quantité à produire
+FeatureDoesntHandleLotBatch=Cette fonctionnalité ne prend pas en compte les numéros de lots et séries
+MakingProductFromAssociatedProducts=Permettre la fabrication d'un produit à partir des produits virtuels

--- a/htdocs/langs/fr_FR/stocks.lang
+++ b/htdocs/langs/fr_FR/stocks.lang
@@ -214,3 +214,5 @@ StockIncrease=Augmentation du stock
 StockDecrease=Diminution du stock
 MakingProductFromVirtualProduct=Fabrication du produit %s depuis les produits virtuels
 ErrorDuringStockMovement=Erreur pendant le mouvement de stock
+ComponentWarehouses=Entrepôt des composants
+ManufacturedProductWarehouse=Entrepôt où le produit fabriqué sera stocké

--- a/htdocs/langs/fr_FR/stocks.lang
+++ b/htdocs/langs/fr_FR/stocks.lang
@@ -212,3 +212,5 @@ StockIncreaseAfterCorrectTransfer=Augmentation par correction/transfert
 StockDecreaseAfterCorrectTransfer=Diminution par correction/transfert
 StockIncrease=Augmentation du stock
 StockDecrease=Diminution du stock
+MakingProduct=Fabrication du produit pour %s
+ErrorDuringStockMovement=Erreur pendant le mouvement de stock

--- a/htdocs/langs/fr_FR/stocks.lang
+++ b/htdocs/langs/fr_FR/stocks.lang
@@ -212,5 +212,5 @@ StockIncreaseAfterCorrectTransfer=Augmentation par correction/transfert
 StockDecreaseAfterCorrectTransfer=Diminution par correction/transfert
 StockIncrease=Augmentation du stock
 StockDecrease=Diminution du stock
-MakingProduct=Fabrication du produit pour %s
+MakingProductFromVirtualProduct=Fabrication du produit %s depuis les produits virtuels
 ErrorDuringStockMovement=Erreur pendant le mouvement de stock

--- a/htdocs/product/admin/product.php
+++ b/htdocs/product/admin/product.php
@@ -132,6 +132,9 @@ if ($action == 'other')
 	$value = GETPOST('PRODUIT_SOUSPRODUITS', 'alpha');
 	$res = dolibarr_set_const($db, "PRODUIT_SOUSPRODUITS", $value, 'chaine', 0, '', $conf->entity);
 
+	$value = GETPOST('PRODUIT_SOUSPRODUITS_MAKINGPRODUCT', 'alpha');
+	$res = dolibarr_set_const($db, "PRODUIT_SOUSPRODUITS_MAKINGPRODUCT", $value, 'chaine', 0, '', $conf->entity);
+
 	$value = GETPOST('activate_viewProdDescInForm', 'alpha');
 	$res = dolibarr_set_const($db, "PRODUIT_DESC_IN_FORM", $value, 'chaine', 0, '', $conf->entity);
 
@@ -598,6 +601,14 @@ print '<td width="60" class="right">';
 print $form->selectyesno("PRODUIT_SOUSPRODUITS", $conf->global->PRODUIT_SOUSPRODUITS, 1);
 print '</td>';
 print '</tr>';
+if(!empty($conf->stock->enabled)) {
+    print '<tr class="oddeven">';
+    print '<td>'.$form->textwithpicto($langs->trans('MakingProductFromAssociatedProducts'), $langs->trans('FeatureDoesntHandleLotBatch')).'</td>';
+    print '<td width="60" class="right">';
+    print $form->selectyesno("PRODUIT_SOUSPRODUITS_MAKINGPRODUCT", $conf->global->PRODUIT_SOUSPRODUITS_MAKINGPRODUCT, 1);
+    print '</td>';
+    print '</tr>';
+}
 
 // Utilisation formulaire Ajax sur choix produit
 

--- a/htdocs/product/composition/card.php
+++ b/htdocs/product/composition/card.php
@@ -33,6 +33,7 @@ require_once DOL_DOCUMENT_ROOT.'/core/lib/product.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
 require_once DOL_DOCUMENT_ROOT.'/product/class/html.formproduct.class.php';
+require_once DOL_DOCUMENT_ROOT.'/product/stock/class/mouvementstock.class.php';
 
 // Load translation files required by the page
 $langs->loadLangs(array('bills', 'products', 'stocks'));
@@ -44,6 +45,9 @@ $confirm=GETPOST('confirm', 'alpha');
 $cancel=GETPOST('cancel', 'alpha');
 $key=GETPOST('key');
 $parent=GETPOST('parent');
+$entryWarehouse=GETPOST('entrywarehouse', 'int');
+$qtyToMake=GETPOST('qty_to_make');
+$TOutletWarehouse = array();
 
 // Security check
 if (! empty($user->societe_id)) $socid=$user->societe_id;
@@ -134,11 +138,47 @@ elseif($action==='save_composed_product')
 }
 elseif($action === 'confirm_makeproduct')
 {
-
+    $error = 0;
+    foreach($_REQUEST as $key => $val) {
+        if(strpos($key,'outletwarehouse') !== false || strpos($key,'qtyneeded') !== false) {
+            $tmpArr = explode('_',$key);
+            if(strpos($key,'outletwarehouse') !== false) $TOutletWarehouse[$tmpArr[1]]['fk_warehouse'] = $val;
+            if(strpos($key,'qtyneeded') !== false) $TOutletWarehouse[$tmpArr[1]]['qty'] = $val;
+        }
+    }
+    if(strpos($qtyToMake,',') !== false) $qtyToMake = price2num($qtyToMake);
+    if(!empty($id) && !empty($entryWarehouse) && !empty($TOutletWarehouse) && (is_numeric($qtyToMake) && $qtyToMake > 0)) {
+        $db->begin();
+        $mvtStock = new MouvementStock($db);
+        $mvtStock->origin = $object;
+        $res = $mvtStock->reception($user,$id,$entryWarehouse, $qtyToMake, 0, $langs->trans('MakingProduct',$object->ref)); //TO MAKE
+        var_dump($res, $id);
+        if($res > 0) {
+            foreach($TOutletWarehouse as $fk_product_needed => $TInfoWarehouse) {
+                $qtyNeeded = $TInfoWarehouse['qty'] * $qtyToMake;
+                $res = $mvtStock->livraison($user, $fk_product_needed, $TInfoWarehouse['fk_warehouse'], $qtyNeeded,0 ,$langs->trans('MakingProduct',$object->ref)); //NEEDED
+                if($res <= 0) {
+                    setEventMessage($langs->trans('ErrorDuringStockMovement'),'errors');
+                    $error++;
+                }
+            }
+        } else {
+            setEventMessage($langs->trans('ErrorDuringStockMovement'),'errors');
+            $error++;
+        }
+    }
+    else {
+        setEventMessage($langs->trans('DolibarrHasDetectedError'), 'errors');
+        $error++;
+    }
     if (! $error)
     {
+        $db->commit();
+        setEventMessage($langs->trans('StockMovementRecorded'), 'mesgs');
         header("Location: ".$_SERVER["PHP_SELF"].'?id='.$object->id);
         exit;
+    } else {
+        $db->rollback();
     }
 }
 
@@ -290,21 +330,24 @@ if ($id > 0 || ! empty($ref))
             $TConfirmParams['id']['value'] = $id;
 
             $TConfirmParams['tomake']['label'] = $langs->trans('QtyToMake').' :';
-            $TConfirmParams['tomake']['type'] = "other";
+            $TConfirmParams['tomake']['type'] = "text";
             $TConfirmParams['tomake']['name'] = "qty_to_make";
-            $TConfirmParams['tomake']['value'] = '<input type="number" name="qty_to_make" min="0" value="0"/>';
 
             $TConfirmParams['target']['label'] = $langs->trans('WarehouseTarget').' :';
             $TConfirmParams['target']['type'] = "other";
-            $TConfirmParams['tomake']['name'] = "entrywarehouse";
+            $TConfirmParams['target']['name'] = "entrywarehouse";
             $TConfirmParams['target']['value'] = $formProduct->selectWarehouses('', 'entrywarehouse');
 
             foreach($prods_arbo as $child) {
                 $fk_child = $child['id'];
                 $TConfirmParams['source'.$fk_child]['label'] = $langs->trans('WarehouseSource').' '.$child['ref'].' :';
-                $TConfirmParams['source'.$fk_child]['name'] = 'outletwarehouse'.$fk_child;
+                $TConfirmParams['source'.$fk_child]['name'] = 'outletwarehouse_'.$fk_child; //Select2 doesnt handle array
                 $TConfirmParams['source'.$fk_child]['type'] = "other";
-                $TConfirmParams['source'.$fk_child]['value'] = $formProduct->selectWarehouses('', 'outletwarehouse'.$fk_child);
+                $TConfirmParams['source'.$fk_child]['value'] = $formProduct->selectWarehouses('', 'outletwarehouse_'.$fk_child);
+
+                $TConfirmParams['qtyneeded'.$fk_child]['name'] = 'qtyneeded_'.$fk_child;
+                $TConfirmParams['qtyneeded'.$fk_child]['type'] = "hidden";
+                $TConfirmParams['qtyneeded'.$fk_child]['value'] = $child['nb'];
             }
             print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans('MakeProduct'), '', 'confirm_makeproduct', $TConfirmParams, '', 1, 'auto');
             $action = '';

--- a/htdocs/product/composition/card.php
+++ b/htdocs/product/composition/card.php
@@ -323,35 +323,40 @@ if ($id > 0 || ! empty($ref))
 		$prodschild = $object->getChildsArbo($id, 1);
 		$nbofsubproducts=count($prodschild);		// This include only first level of childs
 
-        if($action === 'makeproduct' && !empty($conf->global->PRODUIT_SOUSPRODUITS_MAKINGPRODUCT)) {
-            $TConfirmParams = array();
-            $TConfirmParams['id']['name'] = "id";
-            $TConfirmParams['id']['type'] = "hidden";
-            $TConfirmParams['id']['value'] = $id;
+        $TConfirmParams = array();
+        $TConfirmParams['id']['name'] = "id";
+        $TConfirmParams['id']['type'] = "hidden";
+        $TConfirmParams['id']['value'] = $id;
 
-            $TConfirmParams['tomake']['label'] = $langs->trans('QtyToMake').' :';
-            $TConfirmParams['tomake']['type'] = "text";
-            $TConfirmParams['tomake']['name'] = "qty_to_make";
+        $TConfirmParams['tomake']['label'] = $langs->trans('QtyToMake').' :';
+        $TConfirmParams['tomake']['type'] = "text";
+        $TConfirmParams['tomake']['name'] = "qty_to_make";
 
-            $TConfirmParams['target']['label'] = $langs->trans('WarehouseTarget').' :';
-            $TConfirmParams['target']['type'] = "other";
-            $TConfirmParams['target']['name'] = "entrywarehouse";
-            $TConfirmParams['target']['value'] = $formProduct->selectWarehouses('', 'entrywarehouse');
+        $TConfirmParams['finishedtitle']['type'] = 'onecolumn';
+        $TConfirmParams['finishedtitle']['value'] = '<div align="center" width="100%"><b>'.$langs->trans('ManufacturedProductWarehouse').'</b></div>';
 
-            foreach($prods_arbo as $child) {
-                $fk_child = $child['id'];
-                $TConfirmParams['source'.$fk_child]['label'] = $langs->trans('WarehouseSource').' '.$child['ref'].' :';
-                $TConfirmParams['source'.$fk_child]['name'] = 'outletwarehouse_'.$fk_child; //Select2 doesnt handle array
-                $TConfirmParams['source'.$fk_child]['type'] = "other";
-                $TConfirmParams['source'.$fk_child]['value'] = $formProduct->selectWarehouses('', 'outletwarehouse_'.$fk_child);
+        $TConfirmParams['target']['label'] = $langs->trans('WarehouseTarget').' :';
+        $TConfirmParams['target']['type'] = "other";
+        $TConfirmParams['target']['name'] = "entrywarehouse";
+        $TConfirmParams['target']['value'] = $formProduct->selectWarehouses('', 'entrywarehouse');
 
-                $TConfirmParams['qtyneeded'.$fk_child]['name'] = 'qtyneeded_'.$fk_child;
-                $TConfirmParams['qtyneeded'.$fk_child]['type'] = "hidden";
-                $TConfirmParams['qtyneeded'.$fk_child]['value'] = $child['nb'];
-            }
-            print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans('MakeProduct'), '', 'confirm_makeproduct', $TConfirmParams, '', 1, 'auto');
-            $action = '';
+        $TConfirmParams['componenttitle']['type'] = 'onecolumn';
+        $TConfirmParams['componenttitle']['value'] = '<div align="center" width="100%"><b>'.$langs->trans('ComponentWarehouses').'</b></div>';
+
+        foreach($prods_arbo as $child) {
+            $fk_child = $child['id'];
+            $TConfirmParams['source'.$fk_child]['label'] = $langs->trans('WarehouseSource').' '.$child['ref'].' :';
+            $TConfirmParams['source'.$fk_child]['name'] = 'outletwarehouse_'.$fk_child; //Select2 doesnt handle array
+            $TConfirmParams['source'.$fk_child]['type'] = "other";
+            $TConfirmParams['source'.$fk_child]['value'] = $formProduct->selectWarehouses('', 'outletwarehouse_'.$fk_child);
+
+            $TConfirmParams['qtyneeded'.$fk_child]['name'] = 'qtyneeded_'.$fk_child;
+            $TConfirmParams['qtyneeded'.$fk_child]['type'] = "hidden";
+            $TConfirmParams['qtyneeded'.$fk_child]['value'] = $child['nb'];
         }
+        print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans('MakeProduct'), '', 'confirm_makeproduct', $TConfirmParams, '', 'action-makeproduct', 'auto');
+        $action = '';
+
 
 		print '<div class="fichecenter">';
 
@@ -603,7 +608,7 @@ if ($id > 0 || ! empty($ref))
             $parameters = array();
             $reshook = $hookmanager->executeHooks('addMoreActionsButtons', $parameters, $object, $action);    // Note that $action and $object may have been modified by hook
             if(empty($reshook)) {
-                if(!empty($conf->stock->enabled) && !empty($conf->global->PRODUIT_SOUSPRODUITS_MAKINGPRODUCT) && !empty($prods_arbo)) print '<div class="inline-block divButAction" id="btMkProduct"><a href="'.$_SERVER["PHP_SELF"].'?action=makeproduct&id='.$id.'" class="butAction" >'.$langs->trans("MakeProduct").'</a></div>';
+                if(!empty($conf->stock->enabled) && !empty($conf->global->PRODUIT_SOUSPRODUITS_MAKINGPRODUCT) && !empty($prods_arbo)) print '<div class="inline-block divButAction" id="btMkProduct"><span id="action-makeproduct" class="butAction">'.$langs->trans("MakeProduct").'</span></div>';
             }
             print '</div>';
         }

--- a/htdocs/product/composition/card.php
+++ b/htdocs/product/composition/card.php
@@ -32,6 +32,7 @@ require '../../main.inc.php';
 require_once DOL_DOCUMENT_ROOT.'/core/lib/product.lib.php';
 require_once DOL_DOCUMENT_ROOT.'/product/class/product.class.php';
 require_once DOL_DOCUMENT_ROOT.'/categories/class/categorie.class.php';
+require_once DOL_DOCUMENT_ROOT.'/product/class/html.formproduct.class.php';
 
 // Load translation files required by the page
 $langs->loadLangs(array('bills', 'products', 'stocks'));
@@ -50,6 +51,9 @@ $fieldvalue = (! empty($id) ? $id : (! empty($ref) ? $ref : ''));
 $fieldtype = (! empty($ref) ? 'ref' : 'rowid');
 $result=restrictedArea($user, 'produit|service', $fieldvalue, 'product&product', '', '', $fieldtype);
 
+// Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
+$hookmanager->initHooks(array('productcompositioncard'));
+
 $object = new Product($db);
 $objectid=0;
 if ($id > 0 || ! empty($ref))
@@ -66,6 +70,8 @@ if ($id > 0 || ! empty($ref))
 
 if ($cancel) $action ='';
 
+$parameters=array('id'=>$id, 'ref'=>$ref);
+$reshook=$hookmanager->executeHooks('doActions', $parameters, $object, $action);    // Note that $action and $object may have been modified by some hooks
 // Action association d'un sousproduit
 if ($action == 'add_prod' && ($user->rights->produit->creer || $user->rights->service->creer))
 {
@@ -126,7 +132,15 @@ elseif($action==='save_composed_product')
 	}
 	$action='';
 }
+elseif($action === 'confirm_makeproduct')
+{
 
+    if (! $error)
+    {
+        header("Location: ".$_SERVER["PHP_SELF"].'?id='.$object->id);
+        exit;
+    }
+}
 
 /*
  * View
@@ -135,6 +149,7 @@ elseif($action==='save_composed_product')
 $product_fourn = new ProductFournisseur($db);
 $productstatic = new Product($db);
 $form = new Form($db);
+$formProduct = new FormProduct($db);
 
 // action recherche des produits par mot-cle et/ou par categorie
 if ($action == 'search')
@@ -263,10 +278,37 @@ if ($id > 0 || ! empty($ref))
 		$object->get_sousproduits_arbo();			// Load $object->sousprods
 		$prods_arbo=$object->get_arbo_each_prod();
 
+
 		$nbofsubsubproducts=count($prods_arbo);		// This include sub sub product into nb
 		$prodschild = $object->getChildsArbo($id, 1);
 		$nbofsubproducts=count($prodschild);		// This include only first level of childs
 
+        if($action === 'makeproduct') {
+            $TConfirmParams = array();
+            $TConfirmParams['id']['name'] = "id";
+            $TConfirmParams['id']['type'] = "hidden";
+            $TConfirmParams['id']['value'] = $id;
+
+            $TConfirmParams['tomake']['label'] = $langs->trans('QtyToMake').' :';
+            $TConfirmParams['tomake']['type'] = "other";
+            $TConfirmParams['tomake']['name'] = "qty_to_make";
+            $TConfirmParams['tomake']['value'] = '<input type="number" name="qty_to_make" min="0" value="0"/>';
+
+            $TConfirmParams['target']['label'] = $langs->trans('WarehouseTarget').' :';
+            $TConfirmParams['target']['type'] = "other";
+            $TConfirmParams['tomake']['name'] = "entrywarehouse";
+            $TConfirmParams['target']['value'] = $formProduct->selectWarehouses('', 'entrywarehouse');
+
+            foreach($prods_arbo as $child) {
+                $fk_child = $child['id'];
+                $TConfirmParams['source'.$fk_child]['label'] = $langs->trans('WarehouseSource').' '.$child['ref'].' :';
+                $TConfirmParams['source'.$fk_child]['name'] = 'outletwarehouse'.$fk_child;
+                $TConfirmParams['source'.$fk_child]['type'] = "other";
+                $TConfirmParams['source'.$fk_child]['value'] = $formProduct->selectWarehouses('', 'outletwarehouse'.$fk_child);
+            }
+            print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans('MakeProduct'), '', 'confirm_makeproduct', $TConfirmParams, '', 1, 'auto');
+            $action = '';
+        }
 
 		print '<div class="fichecenter">';
 
@@ -514,7 +556,14 @@ if ($id > 0 || ! empty($ref))
 			print '<input type="submit" class="button" value="'.$langs->trans("Search").'">';
 			print '</div>';
 			print '</form>';
-		}
+            print "\n".'<div class="tabsAction">'."\n";
+            $parameters = array();
+            $reshook = $hookmanager->executeHooks('addMoreActionsButtons', $parameters, $object, $action);    // Note that $action and $object may have been modified by hook
+            if(empty($reshook)) {
+                if(!empty($conf->stock->enabled)) print '<div class="inline-block divButAction" id="btMkProduct"><a href="'.$_SERVER["PHP_SELF"].'?action=makeproduct&id='.$id.'" class="butAction" >'.$langs->trans("MakeProduct").'</a></div>';
+            }
+            print '</div>';
+        }
 
 
 		// List of products

--- a/htdocs/product/composition/card.php
+++ b/htdocs/product/composition/card.php
@@ -152,7 +152,6 @@ elseif($action === 'confirm_makeproduct' && !empty($conf->global->PRODUIT_SOUSPR
         $mvtStock = new MouvementStock($db);
         $mvtStock->origin = $object;
         $res = $mvtStock->reception($user,$id,$entryWarehouse, $qtyToMake, 0, $langs->trans('MakingProductFromVirtualProduct',$object->ref)); //TO MAKE
-        var_dump($res, $id);
         if($res > 0) {
             foreach($TOutletWarehouse as $fk_product_needed => $TInfoWarehouse) {
                 $qtyNeeded = $TInfoWarehouse['qty'] * $qtyToMake;

--- a/htdocs/product/composition/card.php
+++ b/htdocs/product/composition/card.php
@@ -136,7 +136,7 @@ elseif($action==='save_composed_product')
 	}
 	$action='';
 }
-elseif($action === 'confirm_makeproduct')
+elseif($action === 'confirm_makeproduct' && !empty($conf->global->PRODUIT_SOUSPRODUITS_MAKINGPRODUCT))
 {
     $error = 0;
     foreach($_REQUEST as $key => $val) {
@@ -151,12 +151,12 @@ elseif($action === 'confirm_makeproduct')
         $db->begin();
         $mvtStock = new MouvementStock($db);
         $mvtStock->origin = $object;
-        $res = $mvtStock->reception($user,$id,$entryWarehouse, $qtyToMake, 0, $langs->trans('MakingProduct',$object->ref)); //TO MAKE
+        $res = $mvtStock->reception($user,$id,$entryWarehouse, $qtyToMake, 0, $langs->trans('MakingProductFromVirtualProduct',$object->ref)); //TO MAKE
         var_dump($res, $id);
         if($res > 0) {
             foreach($TOutletWarehouse as $fk_product_needed => $TInfoWarehouse) {
                 $qtyNeeded = $TInfoWarehouse['qty'] * $qtyToMake;
-                $res = $mvtStock->livraison($user, $fk_product_needed, $TInfoWarehouse['fk_warehouse'], $qtyNeeded,0 ,$langs->trans('MakingProduct',$object->ref)); //NEEDED
+                $res = $mvtStock->livraison($user, $fk_product_needed, $TInfoWarehouse['fk_warehouse'], $qtyNeeded,0 ,$langs->trans('MakingProductFromVirtualProduct',$object->ref)); //NEEDED
                 if($res <= 0) {
                     setEventMessage($langs->trans('ErrorDuringStockMovement'),'errors');
                     $error++;
@@ -323,7 +323,7 @@ if ($id > 0 || ! empty($ref))
 		$prodschild = $object->getChildsArbo($id, 1);
 		$nbofsubproducts=count($prodschild);		// This include only first level of childs
 
-        if($action === 'makeproduct') {
+        if($action === 'makeproduct' && !empty($conf->global->PRODUIT_SOUSPRODUITS_MAKINGPRODUCT)) {
             $TConfirmParams = array();
             $TConfirmParams['id']['name'] = "id";
             $TConfirmParams['id']['type'] = "hidden";
@@ -603,7 +603,7 @@ if ($id > 0 || ! empty($ref))
             $parameters = array();
             $reshook = $hookmanager->executeHooks('addMoreActionsButtons', $parameters, $object, $action);    // Note that $action and $object may have been modified by hook
             if(empty($reshook)) {
-                if(!empty($conf->stock->enabled)) print '<div class="inline-block divButAction" id="btMkProduct"><a href="'.$_SERVER["PHP_SELF"].'?action=makeproduct&id='.$id.'" class="butAction" >'.$langs->trans("MakeProduct").'</a></div>';
+                if(!empty($conf->stock->enabled) && !empty($conf->global->PRODUIT_SOUSPRODUITS_MAKINGPRODUCT) && !empty($prods_arbo)) print '<div class="inline-block divButAction" id="btMkProduct"><a href="'.$_SERVER["PHP_SELF"].'?action=makeproduct&id='.$id.'" class="butAction" >'.$langs->trans("MakeProduct").'</a></div>';
             }
             print '</div>';
         }

--- a/htdocs/product/composition/card.php
+++ b/htdocs/product/composition/card.php
@@ -322,40 +322,39 @@ if ($id > 0 || ! empty($ref))
 		$nbofsubsubproducts=count($prods_arbo);		// This include sub sub product into nb
 		$prodschild = $object->getChildsArbo($id, 1);
 		$nbofsubproducts=count($prodschild);		// This include only first level of childs
+        if(!empty($conf->global->PRODUIT_SOUSPRODUITS_MAKINGPRODUCT) && !empty($prods_arbo)) {
+            $TConfirmParams = array();
+            $TConfirmParams['id']['name'] = "id";
+            $TConfirmParams['id']['type'] = "hidden";
+            $TConfirmParams['id']['value'] = $id;
 
-        $TConfirmParams = array();
-        $TConfirmParams['id']['name'] = "id";
-        $TConfirmParams['id']['type'] = "hidden";
-        $TConfirmParams['id']['value'] = $id;
+            $TConfirmParams['tomake']['label'] = $langs->trans('QtyToMake').' :';
+            $TConfirmParams['tomake']['type'] = "text";
+            $TConfirmParams['tomake']['name'] = "qty_to_make";
 
-        $TConfirmParams['tomake']['label'] = $langs->trans('QtyToMake').' :';
-        $TConfirmParams['tomake']['type'] = "text";
-        $TConfirmParams['tomake']['name'] = "qty_to_make";
+            $TConfirmParams['finishedtitle']['type'] = 'onecolumn';
+            $TConfirmParams['finishedtitle']['value'] = '<div align="center" width="100%"><b>'.$langs->trans('ManufacturedProductWarehouse').'</b></div>';
 
-        $TConfirmParams['finishedtitle']['type'] = 'onecolumn';
-        $TConfirmParams['finishedtitle']['value'] = '<div align="center" width="100%"><b>'.$langs->trans('ManufacturedProductWarehouse').'</b></div>';
+            $TConfirmParams['target']['label'] = $langs->trans('WarehouseTarget').' :';
+            $TConfirmParams['target']['type'] = "other";
+            $TConfirmParams['target']['name'] = "entrywarehouse";
+            $TConfirmParams['target']['value'] = $formProduct->selectWarehouses('', 'entrywarehouse');
 
-        $TConfirmParams['target']['label'] = $langs->trans('WarehouseTarget').' :';
-        $TConfirmParams['target']['type'] = "other";
-        $TConfirmParams['target']['name'] = "entrywarehouse";
-        $TConfirmParams['target']['value'] = $formProduct->selectWarehouses('', 'entrywarehouse');
+            $TConfirmParams['componenttitle']['type'] = 'onecolumn';
+            $TConfirmParams['componenttitle']['value'] = '<div align="center" width="100%"><b>'.$langs->trans('ComponentWarehouses').'</b></div>';
+            foreach($prods_arbo as $child) {
+                $fk_child = $child['id'];
+                $TConfirmParams['source'.$fk_child]['label'] = $langs->trans('WarehouseSource').' '.$child['ref'].' :';
+                $TConfirmParams['source'.$fk_child]['name'] = 'outletwarehouse_'.$fk_child; //Select2 doesnt handle array
+                $TConfirmParams['source'.$fk_child]['type'] = "other";
+                $TConfirmParams['source'.$fk_child]['value'] = $formProduct->selectWarehouses('', 'outletwarehouse_'.$fk_child);
 
-        $TConfirmParams['componenttitle']['type'] = 'onecolumn';
-        $TConfirmParams['componenttitle']['value'] = '<div align="center" width="100%"><b>'.$langs->trans('ComponentWarehouses').'</b></div>';
-
-        foreach($prods_arbo as $child) {
-            $fk_child = $child['id'];
-            $TConfirmParams['source'.$fk_child]['label'] = $langs->trans('WarehouseSource').' '.$child['ref'].' :';
-            $TConfirmParams['source'.$fk_child]['name'] = 'outletwarehouse_'.$fk_child; //Select2 doesnt handle array
-            $TConfirmParams['source'.$fk_child]['type'] = "other";
-            $TConfirmParams['source'.$fk_child]['value'] = $formProduct->selectWarehouses('', 'outletwarehouse_'.$fk_child);
-
-            $TConfirmParams['qtyneeded'.$fk_child]['name'] = 'qtyneeded_'.$fk_child;
-            $TConfirmParams['qtyneeded'.$fk_child]['type'] = "hidden";
-            $TConfirmParams['qtyneeded'.$fk_child]['value'] = $child['nb'];
+                $TConfirmParams['qtyneeded'.$fk_child]['name'] = 'qtyneeded_'.$fk_child;
+                $TConfirmParams['qtyneeded'.$fk_child]['type'] = "hidden";
+                $TConfirmParams['qtyneeded'.$fk_child]['value'] = $child['nb'];
+            }
+            print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans('MakeProduct'), '', 'confirm_makeproduct', $TConfirmParams, '', 'action-makeproduct', 'auto');
         }
-        print $form->formconfirm($_SERVER["PHP_SELF"], $langs->trans('MakeProduct'), '', 'confirm_makeproduct', $TConfirmParams, '', 'action-makeproduct', 'auto');
-        $action = '';
 
 
 		print '<div class="fichecenter">';


### PR DESCRIPTION
Ajouter un bouton de création d’un kit sur les produits virtuels pour créer les kits et incrémenter le stock (et décrémenter les composants). Ce bouton ouvrira une fenêtre permettant de saisir la quantité de kits à composer et de l'entrepôt d'entrée en stock et de sortie du stock des composants. Cette action créera les mouvements de stocks correspondant.

Attendre le wysiwyg avant merge