### PR TITLE
6.0_gifi: fix html markup in csv exports

### DIFF
--- a/htdocs/core/modules/export/export_csv.modules.php
+++ b/htdocs/core/modules/export/export_csv.modules.php
@@ -307,10 +307,13 @@ class ExportCsv extends ModeleExports
 
 		// Rule Dolibarr: No HTML
    		//print $charset.' '.$newvalue."\n";
-   		//$newvalue=dol_string_nohtmltag($newvalue,0,$charset);
-   		$newvalue=dol_htmlcleanlastbr($newvalue);
-   		//print $charset.' '.$newvalue."\n";
-		
+		/* --------------- START SPÉCIFIQUE GIFI ---------------------- */
+//		$newvalue=dol_htmlcleanlastbr($newvalue);
+		$newvalue=dol_string_nohtmltag($newvalue,0,$charset); // tk11660 : marquages indésirables dans exports
+		/* --------------- END SPÉCIFIQUE GIFI ---------------------- */
+
+		//print $charset.' '.$newvalue."\n";
+
 		// Rule 1 CSV: No CR, LF in cells (except if USE_STRICT_CSV_RULES is on, we can keep record as it is but we must add quotes)
 		$oldvalue=$newvalue;
 		$newvalue=str_replace("\r",'',$newvalue);


### PR DESCRIPTION
FIX: CSV exports contain unwanted html markup. Preserving markup in exports is standard in Dolibarr, even in 12.0. We could perhaps make it optional in Dolibarr core 13.0 (?).