### PR TITLE
NEW T2219 - Ajout de filtre sur l'écran statistiques des propositions commerciales 

### DIFF
--- a/htdocs/comm/propal/class/propalestats.class.php
+++ b/htdocs/comm/propal/class/propalestats.class.php
@@ -63,7 +63,6 @@ class PropaleStats extends Stats
 		$this->db = $db;
         $this->socid = ($socid > 0 ? $socid : 0);
         $this->userid = $userid;
-        $this->join = '';
 
         if ($mode == 'customer')
         {
@@ -110,21 +109,14 @@ class PropaleStats extends Stats
     public function getNbByMonth($year, $format = 0)
 	{
 		global $user;
-		if ($_POST['showBySignDate_toselect'] == 'on'){
-			$sql = "SELECT date_format(p.date_cloture,'%m') as dm, COUNT(*) as nb";
-		} else {
-			$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, COUNT(*) as nb";
-		}
+		$commerciaux = GETPOST('propal_commercial');
+		$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, COUNT(*) as nb";
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
-		if (isset($_POST['propal_commercial'])){
+		if (!empty($commerciaux)){
 			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
 		}
-		if ($_POST['showBySignDate_toselect'] == 'on'){
-			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
-		} else {
-			$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
-		}
+		$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
 		$sql .= " AND ".$this->where;
 		$sql .= " GROUP BY dm";
         $sql .= $this->db->order('dm', 'DESC');
@@ -163,24 +155,14 @@ class PropaleStats extends Stats
     public function getAmountByMonth($year, $format)
 	{
 		global $user;
-
-		if ($_POST['showBySignDate_toselect'] == 'on')
-		{
-			$sql = "SELECT date_format(p.date_cloture,'%m') as dm, SUM(p.".$this->field.")";
-		} else {
-			$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, SUM(p.".$this->field.")";
-		}
+		$commerciaux = GETPOST('propal_commercial');
+		$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, SUM(p.".$this->field.")";
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
-		if (isset($_POST['propal_commercial'])){
+		if (!empty($commerciaux)){
 			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
 		}
-		if ($_POST['showBySignDate_toselect'] == 'on')
-		{
-			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
-		} else {
-			$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
-		}
+		$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
 		$sql .= " AND ".$this->where;
 		$sql .= " GROUP BY dm";
         $sql .= $this->db->order('dm', 'DESC');
@@ -198,23 +180,14 @@ class PropaleStats extends Stats
     public function getAverageByMonth($year)
 	{
 		global $user;
-
-		if ($_POST['showBySignDate_toselect'] == 'on'){
-			$sql = "SELECT date_format(p.date_cloture,'%m') as dm, AVG(p.".$this->field.")";
-
-		} else {
-			$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, AVG(p.".$this->field.")";
-		}
+		$commerciaux = GETPOST('propal_commercial');
+		$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, AVG(p.".$this->field.")";
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
-		if (isset($_POST['propal_commercial'])){
+		if (!empty($commerciaux)){
 			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
 		}
-		if ($_POST['showBySignDate_toselect'] == 'on'){
-			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
-		} else {
-			$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
-		}
+		$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
 		$sql .= " AND ".$this->where;
 		$sql .= " GROUP BY dm";
         $sql .= $this->db->order('dm', 'DESC');
@@ -230,15 +203,11 @@ class PropaleStats extends Stats
     public function getAllByYear()
 	{
 		global $user;
-		if ($_POST['showBySignDate_toselect'] == 'on'){
-			$sql = "SELECT date_format(p.date_cloture,'%Y') as year, COUNT(*) as nb, SUM(".$this->field.") as total, AVG(".$this->field.") as avg";
-
-		} else {
-			$sql = "SELECT date_format(".$this->field_date.",'%Y') as year, COUNT(*) as nb, SUM(".$this->field.") as total, AVG(".$this->field.") as avg";
-		}
+		$commerciaux = GETPOST('propal_commercial');
+		$sql = "SELECT date_format(".$this->field_date.",'%Y') as year, COUNT(*) as nb, SUM(".$this->field.") as total, AVG(".$this->field.") as avg";
 		$sql.= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
-		if (isset($_POST['propal_commercial'])){
+		if (!empty($commerciaux)){
 			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
 		}
 		$sql.= " WHERE ".$this->where;

--- a/htdocs/comm/propal/class/propalestats.class.php
+++ b/htdocs/comm/propal/class/propalestats.class.php
@@ -118,7 +118,9 @@ class PropaleStats extends Stats
 		}
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
-        $sql .= $this->join;
+		if (isset($_POST['propal_commercial'])){
+			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
+		}
 		if ($_POST['showBySignDate_toselect'] == 'checked'){
 			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
 		} else {
@@ -171,7 +173,9 @@ class PropaleStats extends Stats
 		}
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
-        $sql .= $this->join;
+		if (isset($_POST['propal_commercial'])){
+			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
+		}
 		if ($_POST['showBySignDate_toselect'] == 'checked')
 		{
 			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
@@ -204,7 +208,9 @@ class PropaleStats extends Stats
 		}
 		$sql .= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
-        $sql .= $this->join;
+		if (isset($_POST['propal_commercial'])){
+			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
+		}
 		if ($_POST['showBySignDate_toselect'] == 'checked'){
 			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
 		} else {
@@ -229,6 +235,9 @@ class PropaleStats extends Stats
 		$sql = "SELECT date_format(".$this->field_date.",'%Y') as year, COUNT(*) as nb, SUM(".$this->field.") as total, AVG(".$this->field.") as avg";
 		$sql.= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
+		if (isset($_POST['propal_commercial'])){
+			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
+		}
 		$sql.= " WHERE ".$this->where;
 		$sql.= " GROUP BY year";
         $sql.= $this->db->order('year', 'DESC');

--- a/htdocs/comm/propal/class/propalestats.class.php
+++ b/htdocs/comm/propal/class/propalestats.class.php
@@ -110,8 +110,7 @@ class PropaleStats extends Stats
     public function getNbByMonth($year, $format = 0)
 	{
 		global $user;
-
-		if ($_POST['showBySignDate_toselect'] == 'checked'){
+		if ($_POST['showBySignDate_toselect'] == 'on'){
 			$sql = "SELECT date_format(p.date_cloture,'%m') as dm, COUNT(*) as nb";
 		} else {
 			$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, COUNT(*) as nb";
@@ -121,7 +120,7 @@ class PropaleStats extends Stats
 		if (isset($_POST['propal_commercial'])){
 			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
 		}
-		if ($_POST['showBySignDate_toselect'] == 'checked'){
+		if ($_POST['showBySignDate_toselect'] == 'on'){
 			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
 		} else {
 			$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
@@ -165,7 +164,7 @@ class PropaleStats extends Stats
 	{
 		global $user;
 
-		if ($_POST['showBySignDate_toselect'] == 'checked')
+		if ($_POST['showBySignDate_toselect'] == 'on')
 		{
 			$sql = "SELECT date_format(p.date_cloture,'%m') as dm, SUM(p.".$this->field.")";
 		} else {
@@ -176,7 +175,7 @@ class PropaleStats extends Stats
 		if (isset($_POST['propal_commercial'])){
 			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
 		}
-		if ($_POST['showBySignDate_toselect'] == 'checked')
+		if ($_POST['showBySignDate_toselect'] == 'on')
 		{
 			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
 		} else {
@@ -200,7 +199,7 @@ class PropaleStats extends Stats
 	{
 		global $user;
 
-		if ($_POST['showBySignDate_toselect'] == 'checked'){
+		if ($_POST['showBySignDate_toselect'] == 'on'){
 			$sql = "SELECT date_format(p.date_cloture,'%m') as dm, AVG(p.".$this->field.")";
 
 		} else {
@@ -211,7 +210,7 @@ class PropaleStats extends Stats
 		if (isset($_POST['propal_commercial'])){
 			$sql.=" JOIN ".MAIN_DB_PREFIX.'societe_commerciaux AS sc ON sc.fk_soc=p.fk_soc';
 		}
-		if ($_POST['showBySignDate_toselect'] == 'checked'){
+		if ($_POST['showBySignDate_toselect'] == 'on'){
 			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
 		} else {
 			$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
@@ -231,8 +230,12 @@ class PropaleStats extends Stats
     public function getAllByYear()
 	{
 		global $user;
+		if ($_POST['showBySignDate_toselect'] == 'on'){
+			$sql = "SELECT date_format(p.date_cloture,'%Y') as year, COUNT(*) as nb, SUM(".$this->field.") as total, AVG(".$this->field.") as avg";
 
-		$sql = "SELECT date_format(".$this->field_date.",'%Y') as year, COUNT(*) as nb, SUM(".$this->field.") as total, AVG(".$this->field.") as avg";
+		} else {
+			$sql = "SELECT date_format(".$this->field_date.",'%Y') as year, COUNT(*) as nb, SUM(".$this->field.") as total, AVG(".$this->field.") as avg";
+		}
 		$sql.= " FROM ".$this->from;
 		if (!$user->rights->societe->client->voir && !$this->socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
 		if (isset($_POST['propal_commercial'])){

--- a/htdocs/comm/propal/class/propalestats.class.php
+++ b/htdocs/comm/propal/class/propalestats.class.php
@@ -63,6 +63,7 @@ class PropaleStats extends Stats
 		$this->db = $db;
         $this->socid = ($socid > 0 ? $socid : 0);
         $this->userid = $userid;
+        $this->join = '';
 
         if ($mode == 'customer')
         {
@@ -110,13 +111,22 @@ class PropaleStats extends Stats
 	{
 		global $user;
 
-		$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, COUNT(*) as nb";
-		$sql.= " FROM ".$this->from;
-		if (!$user->rights->societe->client->voir && !$user->socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
-		$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
-		$sql.= " AND ".$this->where;
-		$sql.= " GROUP BY dm";
-        $sql.= $this->db->order('dm', 'DESC');
+		if ($_POST['showBySignDate_toselect'] == 'checked'){
+			$sql = "SELECT date_format(p.date_cloture,'%m') as dm, COUNT(*) as nb";
+		} else {
+			$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, COUNT(*) as nb";
+		}
+		$sql .= " FROM ".$this->from;
+		if (!$user->rights->societe->client->voir && !$user->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
+        $sql .= $this->join;
+		if ($_POST['showBySignDate_toselect'] == 'checked'){
+			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
+		} else {
+			$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
+		}
+		$sql .= " AND ".$this->where;
+		$sql .= " GROUP BY dm";
+        $sql .= $this->db->order('dm', 'DESC');
 
 		$res=$this->_getNbByMonth($year, $sql, $format);
 		return $res;
@@ -153,13 +163,24 @@ class PropaleStats extends Stats
 	{
 		global $user;
 
-		$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, SUM(p.".$this->field.")";
-		$sql.= " FROM ".$this->from;
-		if (!$user->rights->societe->client->voir && !$this->socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
-		$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
-		$sql.= " AND ".$this->where;
-		$sql.= " GROUP BY dm";
-        $sql.= $this->db->order('dm', 'DESC');
+		if ($_POST['showBySignDate_toselect'] == 'checked')
+		{
+			$sql = "SELECT date_format(p.date_cloture,'%m') as dm, SUM(p.".$this->field.")";
+		} else {
+			$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, SUM(p.".$this->field.")";
+		}
+		$sql .= " FROM ".$this->from;
+		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
+        $sql .= $this->join;
+		if ($_POST['showBySignDate_toselect'] == 'checked')
+		{
+			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
+		} else {
+			$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
+		}
+		$sql .= " AND ".$this->where;
+		$sql .= " GROUP BY dm";
+        $sql .= $this->db->order('dm', 'DESC');
 
 		$res=$this->_getAmountByMonth($year, $sql, $format);
 		return $res;
@@ -175,13 +196,23 @@ class PropaleStats extends Stats
 	{
 		global $user;
 
-		$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, AVG(p.".$this->field.")";
-		$sql.= " FROM ".$this->from;
-		if (!$user->rights->societe->client->voir && !$this->socid) $sql.= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
-		$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
-		$sql.= " AND ".$this->where;
-		$sql.= " GROUP BY dm";
-        $sql.= $this->db->order('dm', 'DESC');
+		if ($_POST['showBySignDate_toselect'] == 'checked'){
+			$sql = "SELECT date_format(p.date_cloture,'%m') as dm, AVG(p.".$this->field.")";
+
+		} else {
+			$sql = "SELECT date_format(".$this->field_date.",'%m') as dm, AVG(p.".$this->field.")";
+		}
+		$sql .= " FROM ".$this->from;
+		if (!$user->rights->societe->client->voir && !$this->socid) $sql .= ", ".MAIN_DB_PREFIX."societe_commerciaux as sc";
+        $sql .= $this->join;
+		if ($_POST['showBySignDate_toselect'] == 'checked'){
+			$sql.= " WHERE p.date_cloture BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
+		} else {
+			$sql.= " WHERE ".$this->field_date." BETWEEN '".$this->db->idate(dol_get_first_day($year))."' AND '".$this->db->idate(dol_get_last_day($year))."'";
+		}
+		$sql .= " AND ".$this->where;
+		$sql .= " GROUP BY dm";
+        $sql .= $this->db->order('dm', 'DESC');
 
 		return $this->_getAverageByMonth($year, $sql);
 	}

--- a/htdocs/comm/propal/stats/index.php
+++ b/htdocs/comm/propal/stats/index.php
@@ -262,17 +262,27 @@ print '<div class="fichecenter"><div class="fichethirdleft">';
 	// Status
 	print '<tr><td class="left">'.$langs->trans("Status").'</td><td class="left">';
     $formpropal->selectProposalStatus(($object_status != '' ? $object_status : -1), 0, 0, 1, $mode, 'object_status');
-	if ($object_status == 2)
-	{
-		print "&nbsp;";
-		print "<form method='POST' name='template' action=''class='right'>";
-		if (isset($_POST['showBySignDate_toselect']))
-		{
-			print "<input id='cbsign' class='flat checkforselect' type='checkbox' name='showBySignDate_toselect' value='checked' checked='checked'>&nbsp;".$langs->trans('ShowBySignDate')."<br>";
+
+	print "&nbsp;";
+	if($object_status == Propal::STATUS_SIGNED) $moreclass="";
+	else $moreclass="hideobject";
+
+	?><script>
+	let $statusList = $("select[name='object_status']");
+	$statusList.on('change', function (){
+		let $selectedStatusIndex = $("select[name='object_status'] option:selected").val();
+		console.log($selectedStatusIndex)
+		if ($selectedStatusIndex == <?php echo Propal::STATUS_SIGNED ?>){
+			$('#showBySign').removeClass("hideobject");
 		} else {
-			print "<input id='cbsign' class='flat checkforselect' type='checkbox' name='showBySignDate_toselect' value='checked'>&nbsp;".$langs->trans('ShowBySignDate')."<br>";
+			$('#showBySign').addClass("hideobject");
 		}
-		print "</form>";
+	});
+ 	</script><?php
+	if (isset($_POST['showBySignDate_toselect'])){
+		print "<span id='showBySign' class='$moreclass'><input id='cbsign' class='flat checkforselect hidden' type='checkbox' name='showBySignDate_toselect' checked='checked'>&nbsp;".$langs->trans('ShowBySignDate')."</span>";
+	} else {
+		print "<span id='showBySign' class='$moreclass'><input id='cbsign' class='flat checkforselect hidden' type='checkbox' name='showBySignDate_toselect' value='checked'>&nbsp;".$langs->trans('ShowBySignDate')."</span>";
 	}
 	print '</td></tr>';
 	// Year
@@ -286,7 +296,6 @@ print '<div class="fichecenter"><div class="fichethirdleft">';
 	print '<tr><td class="left">'.$langs->trans("Commercial").'</td><td class="left">';
 	$formpropal->selectProposalCommercial();
 	print '</td></tr>';
-
 	print '<tr><td align="center" colspan="2"><input type="submit" name="submit" class="button" value="'.$langs->trans("Refresh").'"></td></tr>';
 	print '</table>';
 	print '</form>';

--- a/htdocs/comm/propal/stats/index.php
+++ b/htdocs/comm/propal/stats/index.php
@@ -273,14 +273,15 @@ print '<div class="fichecenter"><div class="fichethirdleft">';
 		if ($selectedStatusIndex == <?php echo Propal::STATUS_SIGNED ?>){
 			$('#showBySign').removeClass("hideobject");
 		} else {
+			$('#cbsign').prop("checked", false);
 			$('#showBySign').addClass("hideobject");
 		}
 	});
  	</script><?php
 	if (isset($_POST['showBySignDate_toselect']) && $object_status == Propal::STATUS_SIGNED){
-		print "<span id='showBySign' class='$moreclass'><input id='cbsign' class='flat checkforselect hidden' type='checkbox' name='showBySignDate_toselect' checked='checked'>&nbsp;".$langs->trans('ShowBySignDate')."</span>";
+		print "<span id='showBySign' class='$moreclass'><input id='cbsign' class='flat checkforselect hidden' type='checkbox' name='showBySignDate_toselect' checked='on'>&nbsp;".$langs->trans('ShowBySignDate')."</span>";
 	} else {
-		print "<span id='showBySign' class='$moreclass'><input id='cbsign' class='flat checkforselect hidden' type='checkbox' name='showBySignDate_toselect' value='checked'>&nbsp;".$langs->trans('ShowBySignDate')."</span>";
+		print "<span id='showBySign' class='$moreclass'><input id='cbsign' class='flat checkforselect hidden' type='checkbox' name='showBySignDate_toselect' >&nbsp;".$langs->trans('ShowBySignDate')."</span>";
 	}
 	print '</td></tr>';
 	// Year

--- a/htdocs/comm/propal/stats/index.php
+++ b/htdocs/comm/propal/stats/index.php
@@ -277,7 +277,7 @@ print '<div class="fichecenter"><div class="fichethirdleft">';
 		}
 	});
  	</script><?php
-	if (isset($_POST['showBySignDate_toselect'])){
+	if (isset($_POST['showBySignDate_toselect']) && $object_status == Propal::STATUS_SIGNED){
 		print "<span id='showBySign' class='$moreclass'><input id='cbsign' class='flat checkforselect hidden' type='checkbox' name='showBySignDate_toselect' checked='checked'>&nbsp;".$langs->trans('ShowBySignDate')."</span>";
 	} else {
 		print "<span id='showBySign' class='$moreclass'><input id='cbsign' class='flat checkforselect hidden' type='checkbox' name='showBySignDate_toselect' value='checked'>&nbsp;".$langs->trans('ShowBySignDate')."</span>";

--- a/htdocs/comm/propal/stats/index.php
+++ b/htdocs/comm/propal/stats/index.php
@@ -38,6 +38,8 @@ if ($mode == 'customer' && ! $user->rights->propale->lire) accessforbidden();
 if ($mode == 'supplier' && ! $user->rights->supplier_proposal->lire) accessforbidden();
 
 $object_status=GETPOST('object_status');
+$propal_commercial=GETPOST('propal_commercial');
+$showBySignDate_toselect=GETPOST('showBySignDate_toselect');
 $categ_id = GETPOST('categ_id', 'categ_id');
 $userid=GETPOST('userid', 'int');
 $socid=GETPOST('socid', 'int');
@@ -260,6 +262,18 @@ print '<div class="fichecenter"><div class="fichethirdleft">';
 	// Status
 	print '<tr><td class="left">'.$langs->trans("Status").'</td><td class="left">';
     $formpropal->selectProposalStatus(($object_status != '' ? $object_status : -1), 0, 0, 1, $mode, 'object_status');
+	if ($object_status == 2)
+	{
+		print "&nbsp;";
+		print "<form method='POST' name='template' action=''class='right'>";
+		if (isset($_POST['showBySignDate_toselect']))
+		{
+			print "<input id='cbsign' class='flat checkforselect' type='checkbox' name='showBySignDate_toselect' value='checked' checked='checked'>&nbsp;".$langs->trans('ShowBySignDate')."<br>";
+		} else {
+			print "<input id='cbsign' class='flat checkforselect' type='checkbox' name='showBySignDate_toselect' value='checked'>&nbsp;".$langs->trans('ShowBySignDate')."<br>";
+		}
+		print "</form>";
+	}
 	print '</td></tr>';
 	// Year
 	print '<tr><td class="left">'.$langs->trans("Year").'</td><td class="left">';

--- a/htdocs/comm/propal/stats/index.php
+++ b/htdocs/comm/propal/stats/index.php
@@ -90,8 +90,7 @@ dol_mkdir($dir);
 
 $stats = new PropaleStats($db, $socid, ($userid>0?$userid:0), $mode);
 if ($object_status != '' && $object_status >= 0) $stats->where .= ' AND p.fk_statut IN ('.$db->escape($object_status).')';
-if ($propal_commercial != '' && $propal_commercial >= 0) $stats->where .= ' AND p.rowid IN (SELECT fk_object FROM '.MAIN_DB_PREFIX.'propal_extrafields WHERE commercial='.$propal_commercial.')';
-
+if ($propal_commercial != '' && $propal_commercial >= 0) $stats->where .= " AND sc.fk_user=".$_POST['propal_commercial'];
 // Build graphic number of object
 $data = $stats->getNbByMonthWithPrevYear($endyear, $startyear);
 // $data = array(array('Lib',val1,val2,val3),...)
@@ -188,7 +187,6 @@ else
     if ($mode == 'customer') $fileurl_avg = DOL_URL_ROOT.'/viewimage.php?modulepart=orderstats&file=ordersaverage-'.$year.'.png';
     if ($mode == 'supplier') $fileurl_avg = DOL_URL_ROOT.'/viewimage.php?modulepart=orderstatssupplier&file=ordersaverage-'.$year.'.png';
 }
-
 $px3 = new DolGraph();
 $mesg = $px3->isGraphKo();
 if (! $mesg)

--- a/htdocs/comm/propal/stats/index.php
+++ b/htdocs/comm/propal/stats/index.php
@@ -293,7 +293,7 @@ print '<div class="fichecenter"><div class="fichethirdleft">';
 	print $form->selectarray('year', $arrayyears, $year, 0);
 	print '</td></tr>';
 
-	print '<tr><td class="left">'.$langs->trans("Commercial").'</td><td class="left">';
+	print '<tr><td class="left">'.$langs->trans("Commerciaux").'</td><td class="left">';
 	$formpropal->selectProposalCommercial();
 	print '</td></tr>';
 	print '<tr><td align="center" colspan="2"><input type="submit" name="submit" class="button" value="'.$langs->trans("Refresh").'"></td></tr>';

--- a/htdocs/comm/propal/stats/index.php
+++ b/htdocs/comm/propal/stats/index.php
@@ -89,6 +89,10 @@ dol_mkdir($dir);
 
 
 $stats = new PropaleStats($db, $socid, ($userid>0?$userid:0), $mode);
+if (GETPOST('showBySignDate_toselect') == 'on')
+{
+	$stats->field_date = 'p.date_cloture';
+}
 if ($object_status != '' && $object_status >= 0) $stats->where .= ' AND p.fk_statut IN ('.$db->escape($object_status).')';
 if ($propal_commercial != '' && $propal_commercial >= 0) $stats->where .= " AND sc.fk_user=".$_POST['propal_commercial'];
 // Build graphic number of object

--- a/htdocs/comm/propal/stats/index.php
+++ b/htdocs/comm/propal/stats/index.php
@@ -38,7 +38,7 @@ if ($mode == 'customer' && ! $user->rights->propale->lire) accessforbidden();
 if ($mode == 'supplier' && ! $user->rights->supplier_proposal->lire) accessforbidden();
 
 $object_status=GETPOST('object_status');
-
+$categ_id = GETPOST('categ_id', 'categ_id');
 $userid=GETPOST('userid', 'int');
 $socid=GETPOST('socid', 'int');
 // Security check
@@ -88,6 +88,7 @@ dol_mkdir($dir);
 
 $stats = new PropaleStats($db, $socid, ($userid>0?$userid:0), $mode);
 if ($object_status != '' && $object_status >= 0) $stats->where .= ' AND p.fk_statut IN ('.$db->escape($object_status).')';
+if ($propal_commercial != '' && $propal_commercial >= 0) $stats->where .= ' AND p.rowid IN (SELECT fk_object FROM '.MAIN_DB_PREFIX.'propal_extrafields WHERE commercial='.$propal_commercial.')';
 
 // Build graphic number of object
 $data = $stats->getNbByMonthWithPrevYear($endyear, $startyear);
@@ -258,7 +259,7 @@ print '<div class="fichecenter"><div class="fichethirdleft">';
 	print '</td></tr>';
 	// Status
 	print '<tr><td class="left">'.$langs->trans("Status").'</td><td class="left">';
-    $formpropal->selectProposalStatus(($object_status!=''?$object_status:-1), 0, 0, 1, $mode, 'object_status');
+    $formpropal->selectProposalStatus(($object_status != '' ? $object_status : -1), 0, 0, 1, $mode, 'object_status');
 	print '</td></tr>';
 	// Year
 	print '<tr><td class="left">'.$langs->trans("Year").'</td><td class="left">';

--- a/htdocs/comm/propal/stats/index.php
+++ b/htdocs/comm/propal/stats/index.php
@@ -267,6 +267,11 @@ print '<div class="fichecenter"><div class="fichethirdleft">';
 	arsort($arrayyears);
 	print $form->selectarray('year', $arrayyears, $year, 0);
 	print '</td></tr>';
+
+	print '<tr><td class="left">'.$langs->trans("Commercial").'</td><td class="left">';
+	$formpropal->selectProposalCommercial();
+	print '</td></tr>';
+
 	print '<tr><td align="center" colspan="2"><input type="submit" name="submit" class="button" value="'.$langs->trans("Refresh").'"></td></tr>';
 	print '</table>';
 	print '</form>';

--- a/htdocs/core/class/html.formpropal.class.php
+++ b/htdocs/core/class/html.formpropal.class.php
@@ -142,4 +142,61 @@ class FormPropal
         }
         print '</select>';
     }
+
+	/**
+	 *    Return combo list of differents status of a proposal
+	 *    Values are id of table c_propalst
+	 *
+	 *    @param	string	$selected   	Preselected value
+	 *    @param	int		$short			Use short labels
+	 *    @param	int		$excludedraft	0=All status, 1=Exclude draft status
+	 *    @param	int 	$showempty		1=Add empty line
+	 *    @param    string  $mode           'customer', 'supplier'
+	 *    @param    string  $htmlname       Name of select field
+	 *    @return	void
+	 */
+
+	public function selectProposalCommercial($selected = '', $short = 0, $excludedraft = 0, $showempty = 1, $mode = 'customer', $htmlname = 'propal_commercial')
+	{
+		global $langs;
+
+		$prefix = '';
+		$prefix = "PropalStatus";
+
+		$sql = "SELECT rowid, lastname, firstname FROM " . MAIN_DB_PREFIX . "user";
+		$sql .= " WHERE rowid IN";
+		$sql .= " (SELECT commercial FROM ".MAIN_DB_PREFIX."propal_extrafields)";
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			$num = $this->db->num_rows($resql);
+			$i = 0;
+			if ($num) {
+				while ($i < $num) {
+					$obj = $this->db->fetch_object($resql);
+					$listofcommercial[$i] = array('id' => $obj->rowid, 'lastname' => $obj->lastname, 'firstname' => $obj->firstname);
+					$i++;
+				}
+			}
+		} else {
+			dol_print_error($this->db);
+		}
+
+		print '<select class="flat" name="'.$htmlname.'">';
+		if ($showempty) print '<option value="-1">&nbsp;</option>';
+
+		foreach($listofcommercial as $key => $obj)
+		{
+
+			if ($selected != '' && $selected == $obj['id'])
+			{
+//				TODO
+			}
+			else
+			{
+				print '<option value='.$obj['id'].'>'.$obj['lastname'].'&nbsp;'.$obj['firstname'];
+			}
+			print '</option>';
+		}
+		print '</select>';
+	}
 }

--- a/htdocs/core/class/html.formpropal.class.php
+++ b/htdocs/core/class/html.formpropal.class.php
@@ -183,11 +183,16 @@ class FormPropal
 		print '<select class="flat" name="'.$htmlname.'">';
 		if ($showempty) print '<option value="-1">&nbsp;</option>';
 
+		if (isset($_POST['propal_commercial']) && $_POST['propal_commercial'] != -1)
+		{
+			$selected = $_POST['propal_commercial'];
+		}
+
 		foreach($listofcommercial as $key => $obj)
 		{
 			if ($selected != '' && $selected == $obj['id'])
 			{
-//				TODO
+				print '<option value='.$obj['id'].' selected>'.$obj['firstname'].'&nbsp;'.$obj['lastname'];
 			}
 			else
 			{

--- a/htdocs/core/class/html.formpropal.class.php
+++ b/htdocs/core/class/html.formpropal.class.php
@@ -164,7 +164,7 @@ class FormPropal
 
 		$sql = "SELECT rowid, lastname, firstname FROM " . MAIN_DB_PREFIX . "user";
 		$sql .= " WHERE rowid IN";
-		$sql .= " (SELECT commercial FROM ".MAIN_DB_PREFIX."propal_extrafields) ORDER BY firstname ASC";
+		$sql .= " (SELECT fk_user FROM ".MAIN_DB_PREFIX."societe_commerciaux) ORDER BY firstname ASC";
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$num = $this->db->num_rows($resql);

--- a/htdocs/core/class/html.formpropal.class.php
+++ b/htdocs/core/class/html.formpropal.class.php
@@ -144,8 +144,7 @@ class FormPropal
     }
 
 	/**
-	 *    Return combo list of differents status of a proposal
-	 *    Values are id of table c_propalst
+	 *    Return combo list of all commercial of proposals
 	 *
 	 *    @param	string	$selected   	Preselected value
 	 *    @param	int		$short			Use short labels
@@ -156,7 +155,7 @@ class FormPropal
 	 *    @return	void
 	 */
 
-	public function selectProposalCommercial($selected = '', $short = 0, $excludedraft = 0, $showempty = 1, $mode = 'customer', $htmlname = 'propal_commercial')
+	public function selectProposalCommercial($selected = '', $htmlname = 'propal_commercial', $short = 0, $excludedraft = 0, $showempty = 1, $mode = 'customer')
 	{
 		global $langs;
 
@@ -165,7 +164,7 @@ class FormPropal
 
 		$sql = "SELECT rowid, lastname, firstname FROM " . MAIN_DB_PREFIX . "user";
 		$sql .= " WHERE rowid IN";
-		$sql .= " (SELECT commercial FROM ".MAIN_DB_PREFIX."propal_extrafields)";
+		$sql .= " (SELECT commercial FROM ".MAIN_DB_PREFIX."propal_extrafields) ORDER BY firstname ASC";
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$num = $this->db->num_rows($resql);
@@ -173,7 +172,7 @@ class FormPropal
 			if ($num) {
 				while ($i < $num) {
 					$obj = $this->db->fetch_object($resql);
-					$listofcommercial[$i] = array('id' => $obj->rowid, 'lastname' => $obj->lastname, 'firstname' => $obj->firstname);
+					$listofcommercial[$i] = array('id' => $obj->rowid, 'firstname' => $obj->firstname, 'lastname' => $obj->lastname);
 					$i++;
 				}
 			}
@@ -186,14 +185,13 @@ class FormPropal
 
 		foreach($listofcommercial as $key => $obj)
 		{
-
 			if ($selected != '' && $selected == $obj['id'])
 			{
 //				TODO
 			}
 			else
 			{
-				print '<option value='.$obj['id'].'>'.$obj['lastname'].'&nbsp;'.$obj['firstname'];
+				print '<option value='.$obj['id'].'>'.$obj['firstname'].'&nbsp;'.$obj['lastname'];
 			}
 			print '</option>';
 		}

--- a/htdocs/langs/fr_FR/propal.lang
+++ b/htdocs/langs/fr_FR/propal.lang
@@ -76,7 +76,7 @@ TypeContact_propal_external_BILLING=Contact client facturation proposition
 TypeContact_propal_external_CUSTOMER=Contact client suivi proposition
 TypeContact_propal_external_SHIPPING=Contact client pour la livraison
 # Document models
-DocModelAzurDescription=Un modèle de proposition complet 
+DocModelAzurDescription=Un modèle de proposition complet
 DocModelCyanDescription=Un modèle de proposition complet
 DefaultModelPropalCreate=Modèle par défaut à la création
 DefaultModelPropalToBill=Modèle par défaut lors de la clôture d'une proposition commerciale (à facturer)
@@ -86,3 +86,4 @@ ProposalsStatisticsSuppliers=Statistiques de propositions commerciales
 CaseFollowedBy=Affaire suivie par
 SignedOnly=Signé seulement
 ShowBySignDate = Afficher par date de signature plutôt que par date de création
+Commerciaux=Commerciaux

--- a/htdocs/langs/fr_FR/propal.lang
+++ b/htdocs/langs/fr_FR/propal.lang
@@ -84,3 +84,5 @@ DefaultModelPropalClosed=Modèle par défaut lors de la clôture d'une propositi
 ProposalCustomerSignature=Cachet, Date, Signature et mention "Bon pour Accord"
 ProposalsStatisticsSuppliers=Statistiques de propositions commerciales
 CaseFollowedBy=Affaire suivie par
+SignedOnly=Signé seulement
+ShowBySignDate = Afficher par date de signature plutôt que par date de création


### PR DESCRIPTION
### NEW : Ajout de filtres sur l’écran statistique des propositions commerciales 
Ajout de **2 nouveaux filtres** : une **liste déroulante des commerciaux** affectés aux tiers concernés par les propositions commerciales, et une **checkbox**

**La liste de commerciaux** : après avoir sélectionné un commercial et rechargé la page, cela f**iltrera les propositions commerciales en fonction du commercial affecté au tiers des propositions commerciales**. De plus, les graphiques et tableaux se généreront en conséquence.
**La checkbox** : Lorsque l'on sélectionné le statut "Signée", une checkbox apparaît. Après l'avoir coché et rechargé la page, cela **filtrera les propositions commerciales selon leurs dates de signature et non selon leurs date de création**. Cela montrera également les graphiques et tableaux en conséquences. 
