### PR TITLE
New/11.0 multicurrency rate editor

### DIFF
--- a/htdocs/core/modules/modMultiCurrency.class.php
+++ b/htdocs/core/modules/modMultiCurrency.class.php
@@ -19,13 +19,13 @@
  */
 
 /**
- * 	\defgroup   multicurrency     Module MultiCurrency
+ *    \defgroup   multicurrency     Module MultiCurrency
  *  \brief      Handle multiple currencies on company/propal/orders ...
  *  \file       htdocs/core/modules/modMultiCurrency.class.php
  *  \ingroup    multicurrency
  *  \brief      Description and activation file for module MultiCurrency
  */
-include_once DOL_DOCUMENT_ROOT.'/core/modules/DolibarrModules.class.php';
+include_once DOL_DOCUMENT_ROOT . '/core/modules/DolibarrModules.class.php';
 
 
 /**
@@ -38,11 +38,11 @@ class modMultiCurrency extends DolibarrModules
 	 *
 	 * @param DoliDB $db Database handler
 	 */
-    public function __construct($db)
-    {
-        global $langs, $conf;
+	public function __construct($db)
+	{
+		global $langs, $conf;
 
-        $this->db = $db;
+		$this->db = $db;
 
 		// Id for module (must be unique).
 		// Use here a free id (See in Home -> System information -> Dolibarr for list of used modules id).
@@ -64,7 +64,7 @@ class modMultiCurrency extends DolibarrModules
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or 'dolibarr_deprecated' or version
 		$this->version = 'dolibarr';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
-		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
+		$this->const_name = 'MAIN_MODULE_' . strtoupper($this->name);
 		// Name of image file used for this module.
 		// If file is in theme/yourtheme/img directory under name object_pictovalue.png, use this->picto='pictovalue'
 		// If file is in module/img directory under name object_pictovalue.png, use this->picto='pictovalue@module'
@@ -101,8 +101,8 @@ class modMultiCurrency extends DolibarrModules
 
 		// Array to add new pages in new tabs
 		// Example: $this->tabs = array('objecttype:+tabname1:Title1:mylangfile@multicurrency:$user->rights->multicurrency->read:/multicurrency/mynewtab1.php?id=__ID__',  					// To add a new tab identified by code tabname1
-        //                              'objecttype:+tabname2:SUBSTITUTION_Title2:mylangfile@multicurrency:$user->rights->othermodule->read:/multicurrency/mynewtab2.php?id=__ID__',  	// To add another new tab identified by code tabname2. Label will be result of calling all substitution functions on 'Title2' key.
-        //                              'objecttype:-tabname:NU:conditiontoremove');                                                     										// To remove an existing tab identified by code tabname
+		//                              'objecttype:+tabname2:SUBSTITUTION_Title2:mylangfile@multicurrency:$user->rights->othermodule->read:/multicurrency/mynewtab2.php?id=__ID__',  	// To add another new tab identified by code tabname2. Label will be result of calling all substitution functions on 'Title2' key.
+		//                              'objecttype:-tabname:NU:conditiontoremove');                                                     										// To remove an existing tab identified by code tabname
 		// where objecttype can be
 		// 'categories_x'	  to add a tab in category view (replace 'x' by type of category (0=product, 1=supplier, 2=customer, 3=member)
 		// 'contact'          to add a tab in contact view
@@ -123,35 +123,34 @@ class modMultiCurrency extends DolibarrModules
 		// 'stock'            to add a tab in stock view
 		// 'thirdparty'       to add a tab in third party view
 		// 'user'             to add a tab in user view
-        $this->tabs = array();
+		$this->tabs = array();
 
-        // Dictionaries
-	    if (!isset($conf->multicurrency->enabled))
-        {
-        	$conf->multicurrency = new stdClass();
-        	$conf->multicurrency->enabled = 0;
-        }
+		// Dictionaries
+		if (!isset($conf->multicurrency->enabled)) {
+			$conf->multicurrency = new stdClass();
+			$conf->multicurrency->enabled = 0;
+		}
 		$this->dictionaries = array();
-        /* Example:
-        if (! isset($conf->multicurrency->enabled)) $conf->multicurrency->enabled=0;	// This is to avoid warnings
-        $this->dictionaries=array(
-            'langs'=>'mylangfile@multicurrency',
-            'tabname'=>array(MAIN_DB_PREFIX."table1",MAIN_DB_PREFIX."table2",MAIN_DB_PREFIX."table3"),		// List of tables we want to see into dictonnary editor
-            'tablib'=>array("Table1","Table2","Table3"),													// Label of tables
+		/* Example:
+		if (! isset($conf->multicurrency->enabled)) $conf->multicurrency->enabled=0;	// This is to avoid warnings
+		$this->dictionaries=array(
+			'langs'=>'mylangfile@multicurrency',
+			'tabname'=>array(MAIN_DB_PREFIX."table1",MAIN_DB_PREFIX."table2",MAIN_DB_PREFIX."table3"),		// List of tables we want to see into dictonnary editor
+			'tablib'=>array("Table1","Table2","Table3"),													// Label of tables
 			'tabsql'=>array('SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table1 as f','SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table2 as f','SELECT f.rowid as rowid, f.code, f.label, f.active FROM '.MAIN_DB_PREFIX.'table3 as f'),	// Request to select fields
 			// Sort order
-            'tabsqlsort'=>array("label ASC","label ASC","label ASC"),
-            'tabfield'=>array("code,label","code,label","code,label"),																					// List of fields (result of select to show dictionary)
-            'tabfieldvalue'=>array("code,label","code,label","code,label"),																				// List of fields (list of fields to edit a record)
-            'tabfieldinsert'=>array("code,label","code,label","code,label"),																			// List of fields (list of fields for insert)
-            'tabrowid'=>array("rowid","rowid","rowid"),																									// Name of columns with primary key (try to always name it 'rowid')
-            'tabcond'=>array($conf->multicurrency->enabled,$conf->multicurrency->enabled,$conf->multicurrency->enabled)												// Condition to show each dictionary
-        );
-        */
+			'tabsqlsort'=>array("label ASC","label ASC","label ASC"),
+			'tabfield'=>array("code,label","code,label","code,label"),																					// List of fields (result of select to show dictionary)
+			'tabfieldvalue'=>array("code,label","code,label","code,label"),																				// List of fields (list of fields to edit a record)
+			'tabfieldinsert'=>array("code,label","code,label","code,label"),																			// List of fields (list of fields for insert)
+			'tabrowid'=>array("rowid","rowid","rowid"),																									// Name of columns with primary key (try to always name it 'rowid')
+			'tabcond'=>array($conf->multicurrency->enabled,$conf->multicurrency->enabled,$conf->multicurrency->enabled)												// Condition to show each dictionary
+		);
+		*/
 
-        // Boxes
+		// Boxes
 		// Add here list of php file(s) stored in core/boxes that contains class to show a box.
-        $this->boxes = array(); // List of boxes
+		$this->boxes = array(); // List of boxes
 		// Example:
 		//$this->boxes=array(
 		//    0=>array('file'=>'myboxa.php@multicurrency','note'=>'','enabledbydefaulton'=>'Home'),
@@ -175,19 +174,19 @@ class modMultiCurrency extends DolibarrModules
 		// Main menu entries
 		$this->menu = array(); // List of menus to add
 		$r = 0;
-		 $this->menu[$r]=array(	'fk_menu'=>'fk_mainmenu=tools',		    // '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
-									'type'=>'left',			                // This is a Left menu entry
-									'titre'=>$langs->trans('MulticurrencyRateSetup'),
-									'mainmenu'=>'',
-									'leftmenu'=>'multicurrency',
-									'url'=>'/multicurrency/multicurrency_rates.php',
-									'langs'=>'multicurrency',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
-									'position'=>100,
-									'enabled'=>'$conf->multicurrency->enabled',  // Define condition to show or hide menu entry. Use '$conf->multicurrency->enabled' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
-									'perms'=>'1',			                // Use 'perms'=>'$user->rights->multicurrency->level1->level2' if you want your menu with a permission rules
-									'target'=>'',
-									'user'=>0);				                // 0=Menu for internal users, 1=external users, 2=both
-		 $r++;
+		$this->menu[$r] = array('fk_menu' => 'fk_mainmenu=tools',            // '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
+								'type' => 'left',                            // This is a Left menu entry
+								'titre' => $langs->trans('MulticurrencyRateSetup'),
+								'mainmenu' => '',
+								'leftmenu' => 'multicurrency',
+								'url' => '/multicurrency/multicurrency_rates.php',
+								'langs' => 'multicurrency',            // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+								'position' => 100,
+								'enabled' => '$conf->multicurrency->enabled',  // Define condition to show or hide menu entry. Use '$conf->multicurrency->enabled' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+								'perms' => '1',                            // Use 'perms'=>'$user->rights->multicurrency->level1->level2' if you want your menu with a permission rules
+								'target' => '',
+								'user' => 0);                                // 0=Menu for internal users, 1=external users, 2=both
+		$r++;
 
 		// Add here entries to declare new menus
 		//
@@ -228,8 +227,8 @@ class modMultiCurrency extends DolibarrModules
 		// Example:
 		// $this->export_code[$r]=$this->rights_class.'_'.$r;
 		// $this->export_label[$r]='MyModule';	// Translation key (used only if key ExportDataset_xxx_z not found)
-        // $this->export_enabled[$r]='1';                               // Condition to show export in list (ie: '$user->id==3'). Set to 1 to always show when module is enabled.
-        // $this->export_icon[$r]='generic:MyModule';
+		// $this->export_enabled[$r]='1';                               // Condition to show export in list (ie: '$user->id==3'). Set to 1 to always show when module is enabled.
+		// $this->export_icon[$r]='generic:MyModule';
 		// $this->export_permission[$r]=array(array("multicurrency","level1","level2"));
 		// $this->export_fields_array[$r]=array(
 		//	's.rowid'=>"IdCompany",'s.nom'=>'CompanyName','s.address'=>'Address','s.zip'=>'Zip','s.town'=>'Town','s.fk_pays'=>'Country','s.phone'=>'Phone',
@@ -268,12 +267,12 @@ class modMultiCurrency extends DolibarrModules
 	}
 
 	/**
-	 *		Function called when module is enabled.
-	 *		The init function add constants, boxes, permissions and menus (defined in constructor) into Dolibarr database.
-	 *		It also creates data directories
+	 *        Function called when module is enabled.
+	 *        The init function add constants, boxes, permissions and menus (defined in constructor) into Dolibarr database.
+	 *        It also creates data directories
 	 *
-     *      @param      string	$options    Options when enabling module ('', 'noboxes')
-	 *      @return     int             	1 if OK, 0 if KO
+	 * @param string $options Options when enabling module ('', 'noboxes')
+	 * @return     int                1 if OK, 0 if KO
 	 */
 	public function init($options = '')
 	{
@@ -282,8 +281,7 @@ class modMultiCurrency extends DolibarrModules
 		//$this->_load_tables('/multicurrency/sql/');
 		$res = $this->_init($sql, $options);
 
-		if ($res)
-		{
+		if ($res) {
 			$this->createFirstCurrency();
 		}
 
@@ -291,40 +289,39 @@ class modMultiCurrency extends DolibarrModules
 	}
 
 	/**
+	 * Function called when module is enabled
+	 * Create the currency from general setting
+	 *
+	 * @return    int        1 if OK, 0 if KO
+	 */
+	private function createFirstCurrency()
+	{
+		global $conf, $user, $langs;
+
+		if (!MultiCurrency::checkCodeAlreadyExists($conf->currency)) {
+			$langs->loadCacheCurrencies('');
+
+			$multicurrency = new MultiCurrency($this->db);
+			$multicurrency->code = $conf->currency;
+			$multicurrency->name = $langs->cache_currencies[$conf->currency]['label'] . ' (' . $langs->getCurrencySymbol($conf->currency) . ')';
+			$r = $multicurrency->create($user);
+
+			if ($r > 0) $multicurrency->addRate(1);
+		}
+	}
+
+	/**
 	 * Function called when module is disabled.
 	 * Remove from database constants, boxes and permissions from Dolibarr database.
 	 * Data directories are not deleted
 	 *
-	 * @param      string	$options    Options when enabling module ('', 'noboxes')
-	 * @return     int             	1 if OK, 0 if KO
+	 * @param string $options Options when enabling module ('', 'noboxes')
+	 * @return     int                1 if OK, 0 if KO
 	 */
 	public function remove($options = '')
 	{
 		$sql = array();
 
 		return $this->_remove($sql, $options);
-	}
-
-	/**
-	 * Function called when module is enabled
-	 * Create the currency from general setting
-	 *
-	 * @return 	int		1 if OK, 0 if KO
-	 */
-	private function createFirstCurrency()
-	{
-		global $conf, $user, $langs;
-
-		if (!MultiCurrency::checkCodeAlreadyExists($conf->currency))
-		{
-			$langs->loadCacheCurrencies('');
-
-			$multicurrency = new MultiCurrency($this->db);
-			$multicurrency->code = $conf->currency;
-			$multicurrency->name = $langs->cache_currencies[$conf->currency]['label'].' ('.$langs->getCurrencySymbol($conf->currency).')';
-			$r = $multicurrency->create($user);
-
-			if ($r > 0)	$multicurrency->addRate(1);
-		}
 	}
 }

--- a/htdocs/core/modules/modMultiCurrency.class.php
+++ b/htdocs/core/modules/modMultiCurrency.class.php
@@ -175,6 +175,19 @@ class modMultiCurrency extends DolibarrModules
 		// Main menu entries
 		$this->menu = array(); // List of menus to add
 		$r = 0;
+		 $this->menu[$r]=array(	'fk_menu'=>'fk_mainmenu=tools',		    // '' if this is a top menu. For left menu, use 'fk_mainmenu=xxx' or 'fk_mainmenu=xxx,fk_leftmenu=yyy' where xxx is mainmenucode and yyy is a leftmenucode
+									'type'=>'left',			                // This is a Left menu entry
+									'titre'=>$langs->trans('MulticurrencyRateSetup'),
+									'mainmenu'=>'',
+									'leftmenu'=>'multicurrency',
+									'url'=>'/multicurrency/multicurrency_rates.php',
+									'langs'=>'multicurrency',	        // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
+									'position'=>100,
+									'enabled'=>'$conf->multicurrency->enabled',  // Define condition to show or hide menu entry. Use '$conf->multicurrency->enabled' if entry must be visible if module is enabled. Use '$leftmenu==\'system\'' to show if leftmenu system is selected.
+									'perms'=>'1',			                // Use 'perms'=>'$user->rights->multicurrency->level1->level2' if you want your menu with a permission rules
+									'target'=>'',
+									'user'=>0);				                // 0=Menu for internal users, 1=external users, 2=both
+		 $r++;
 
 		// Add here entries to declare new menus
 		//

--- a/htdocs/langs/en_US/multicurrency.lang
+++ b/htdocs/langs/en_US/multicurrency.lang
@@ -18,3 +18,11 @@ MulticurrencyReceived=Received, original currency
 MulticurrencyRemainderToTake=Remaining amount, original currency
 MulticurrencyPaymentAmount=Payment amount, original currency
 AmountToOthercurrency=Amount To (in currency of receiving account)
+
+ErrorCallbackNotFound=Callback not found: %s
+CurrencyRateSetup=Multi-currency exchange rates
+MulticurrencyRateDeleted=Exchange rate deleted
+MulticurrencyDateSync=Date
+MulticurrencyRate=Exchange rate
+MulticurrencyCode=Currency code
+MulticurrencyEntity=Entity

--- a/htdocs/langs/en_US/multicurrency.lang
+++ b/htdocs/langs/en_US/multicurrency.lang
@@ -20,10 +20,15 @@ MulticurrencyPaymentAmount=Payment amount, original currency
 AmountToOthercurrency=Amount To (in currency of receiving account)
 
 ErrorCallbackNotFound=Callback not found: %s
+MulticurrencyErrorCouldNotCreateRate=Unable to create exchange rate "%s" for currency "%s"
+MulticurrencyErrorCurrencyCodeNotFound=Currency code not found: "%s"
+MulticurrencyErrorCouldNotFetchRate=Exchange rate #%d not found
 CurrencyRateSetup=Multi-currency exchange rates
+MulticurrencyRateSetup=Edit exchange rates
 MulticurrencyRateDeleted=Exchange rate deleted
 MulticurrencyDateSync=Date
 MulticurrencyRate=Exchange rate
 MulticurrencyCode=Currency code
 MulticurrencyEntity=Entity
+MulticurrencyRateSaved=Exchange rate saved
 UnknownAction=Unknown action : "%s"

--- a/htdocs/langs/en_US/multicurrency.lang
+++ b/htdocs/langs/en_US/multicurrency.lang
@@ -26,3 +26,4 @@ MulticurrencyDateSync=Date
 MulticurrencyRate=Exchange rate
 MulticurrencyCode=Currency code
 MulticurrencyEntity=Entity
+UnknownAction=Unknown action : "%s"

--- a/htdocs/langs/fr_FR/multicurrency.lang
+++ b/htdocs/langs/fr_FR/multicurrency.lang
@@ -26,3 +26,4 @@ MulticurrencyDateSync=Date
 MulticurrencyRate=Taux de change
 MulticurrencyCode=Code devise
 MulticurrencyEntity=Entité
+UnknownAction=Action non reconnue : "%s"

--- a/htdocs/langs/fr_FR/multicurrency.lang
+++ b/htdocs/langs/fr_FR/multicurrency.lang
@@ -20,10 +20,15 @@ MulticurrencyPaymentAmount=Montant du règlement (devise d'origine)
 AmountToOthercurrency=Montant destination (en devise du compte de réception)
 
 ErrorCallbackNotFound=Callback introuvable : %s
+MulticurrencyErrorCouldNotCreateRate=Impossible de créer le taux "%s" sur la devise "%s"
+MulticurrencyErrorCurrencyCodeNotFound=Code devise introuvable : "%s"
+MulticurrencyErrorCouldNotFetchRate=Taux de change %d introuvable
 CurrencyRateSetup=Taux de change multi-devise
+MulticurrencyRateSetup=Modifier les taux de change
 MulticurrencyRateDeleted=Taux de change supprimé
 MulticurrencyDateSync=Date
 MulticurrencyRate=Taux de change
 MulticurrencyCode=Code devise
 MulticurrencyEntity=Entité
+MulticurrencyRateSaved=Taux de change enregistré
 UnknownAction=Action non reconnue : "%s"

--- a/htdocs/langs/fr_FR/multicurrency.lang
+++ b/htdocs/langs/fr_FR/multicurrency.lang
@@ -18,3 +18,11 @@ MulticurrencyReceived=Reçu, devise originale
 MulticurrencyRemainderToTake=Montant restant, devise d'origine
 MulticurrencyPaymentAmount=Montant du règlement (devise d'origine)
 AmountToOthercurrency=Montant destination (en devise du compte de réception)
+
+ErrorCallbackNotFound=Callback introuvable : %s
+CurrencyRateSetup=Taux de change multi-devise
+MulticurrencyRateDeleted=Taux de change supprimé
+MulticurrencyDateSync=Date
+MulticurrencyRate=Taux de change
+MulticurrencyCode=Code devise
+MulticurrencyEntity=Entité

--- a/htdocs/multicurrency/class/multicurrency.class.php
+++ b/htdocs/multicurrency/class/multicurrency.class.php
@@ -762,7 +762,9 @@ class CurrencyRate extends CommonObjectLine
 		$error = 0;
 		$this->rate = price2num($this->rate);
 		if (empty($this->entity) || $this->entity <= 0) $this->entity = $conf->entity;
-		$now=date('Y-m-d H:i:s');
+
+		// if no date defined on object, use current date
+		if (empty($this->date_sync)) $this->date_sync = date('Y-m-d H:i:s');
 
 		// Insert request
 		$sql = 'INSERT INTO ' . MAIN_DB_PREFIX . $this->table_element . '(';
@@ -772,7 +774,7 @@ class CurrencyRate extends CommonObjectLine
 		$sql .= ' entity';
 		$sql .= ') VALUES (';
 		$sql .= ' '.$this->rate.',';
-		$sql .= ' \'' . $now . '\',';
+		$sql .= ' \'' . $this->date_sync . '\',';
 		$sql .= ' \'' . $fk_multicurrency . '\',';
 		$sql .= ' \'' . $this->entity . '\'';
 		$sql .= ')';
@@ -871,7 +873,8 @@ class CurrencyRate extends CommonObjectLine
 
 		// Update request
 		$sql = 'UPDATE ' . MAIN_DB_PREFIX . $this->table_element . ' SET';
-		$sql .= ' rate='.$this->rate;
+		$sql .= ' rate=' . $this->rate;
+		if ($this->date_sync) $sql .= ', date_sync="' . $this->db->escape($this->date_sync) . '"';
 		$sql .= ' WHERE rowid=' . $this->id;
 
 		$this->db->begin();

--- a/htdocs/multicurrency/multicurrency_rates.php
+++ b/htdocs/multicurrency/multicurrency_rates.php
@@ -16,11 +16,11 @@
 
 /**
  *      \file       htdocs/multicurrency/multicurrency_rates.php
- *		\ingroup    multicurrency
- *		\brief      Shows an exchange rate editor
+ *        \ingroup    multicurrency
+ *        \brief      Shows an exchange rate editor
  */
 
-$res=@include("../main.inc.php");				// For root directory
+$res = @include("../main.inc.php");                // For root directory
 
 /**
  * @var User $user
@@ -34,15 +34,13 @@ require_once DOL_DOCUMENT_ROOT . '/multicurrency/class/multicurrency.class.php';
 dol_include_once('/multicompany/class/actions_multicompany.class.php', 'ActionsMulticompany');
 /** @var Translate $langs */
 $langs->loadLangs(array(
-	"errors",
-	"admin",
-	"main",
-	"multicurrency"));
+					  "errors",
+					  "admin",
+					  "main",
+					  "multicurrency"));
 
 
-
-if (!$user->admin)
-{
+if (!$user->admin) {
 	accessforbidden();
 }
 
@@ -52,7 +50,7 @@ $hookmanager->initHooks(array('multicurrency_rates'));
 
 // Load translation files required by the page
 
-$action = GETPOST('action', 'alpha') ?GETPOST('action', 'alpha') : 'view';
+$action = GETPOST('action', 'alpha') ? GETPOST('action', 'alpha') : 'view';
 
 // column definition
 $TVisibleColumn = array(
@@ -73,7 +71,8 @@ _completeColumns($db, $TVisibleColumn);
 _handleActions($db, $TVisibleColumn);
 exit;
 
-function _handleActions($db, $TVisibleColumn) {
+function _handleActions($db, $TVisibleColumn)
+{
 	global $langs;
 	$action = GETPOST('action', 'alpha');
 	if (empty($action)) $action = 'view';
@@ -93,7 +92,8 @@ function _handleActions($db, $TVisibleColumn) {
  * @param string $mode
  * @param int|null $targetId ID of the row targeted for edition, deletion, etc.
  */
-function _mainView($db, $TVisibleColumn, $mode='view', $targetId=NULL) {
+function _mainView($db, $TVisibleColumn, $mode = 'view', $targetId = NULL)
+{
 	global $langs;
 	$title = $langs->trans('CurrencyRateSetup');
 	$limit = 1000;
@@ -136,10 +136,10 @@ function _mainView($db, $TVisibleColumn, $mode='view', $targetId=NULL) {
 		 . '  padding: 0;'
 		 . '  background: inherit;'
 		 . '  cursor: pointer;'
-		 .'}'
-		 .'col.small-col {'
+		 . '}'
+		 . 'col.small-col {'
 		 . '  width: 5%'
-		 .'}'
+		 . '}'
 		 . '</style>';
 
 	echo '<table class="noborder centpercent">';
@@ -197,13 +197,13 @@ function _mainView($db, $TVisibleColumn, $mode='view', $targetId=NULL) {
 	}
 	// entire form is inside cell because HTML does not allow forms inside tables unless they are inside cells
 	echo '<td>'
-		 .'<form method="post" id="form-add-new" action="' . $_SERVER["PHP_SELF"] . '">'
+		 . '<form method="post" id="form-add-new" action="' . $_SERVER["PHP_SELF"] . '">'
 		 . _formHiddenInputs($TVisibleColumn)
-		 .'<button class="button" name="action" value="add">'
+		 . '<button class="button" name="action" value="add">'
 		 . $langs->trans('Add')
 		 . '</button>'
-		 .'</form>'
-		 .'</td>';
+		 . '</form>'
+		 . '</td>';
 	echo '</tr>';
 	echo '</tbody>';
 
@@ -221,12 +221,16 @@ function _mainView($db, $TVisibleColumn, $mode='view', $targetId=NULL) {
 		$objId = intval($obj->rowid);
 		$row_is_in_edit_mode = ($mode === 'modify' && $objId === $targetId);
 		$form_update_name = "form-update-" . $objId;
-		if (!$obj) { break; }
+		if (!$obj) {
+			break;
+		}
 		echo '<tr id="row-' . intval($obj->rowid) . '">';
 		foreach ($TVisibleColumn as $colSelect => $colParam) {
 			$rawValue = $obj->{$colParam['name']};
 			$displayMode = 'view';
-			if ($row_is_in_edit_mode) { $displayMode = 'modify'; }
+			if ($row_is_in_edit_mode) {
+				$displayMode = 'modify';
+			}
 			$cellContent = _getCellContent($rawValue, $colParam, $displayMode, $form_update_name);
 			echo '<td class="' . $colParam['name'] . '">' . $cellContent . '</td>';
 		}
@@ -242,9 +246,7 @@ function _mainView($db, $TVisibleColumn, $mode='view', $targetId=NULL) {
 				 . htmlspecialchars($langs->trans('Save'), ENT_QUOTES)
 				 . '" />'
 				 . '</form>';
-		}
-
-		// edit + delete buttons (for rows not in edit mode)
+		} // edit + delete buttons (for rows not in edit mode)
 		else {
 			echo '<form method="post" action="' . $_SERVER['PHP_SELF'] . '" id="form-edit-' . $objId . '" style="display: inline;">'
 				 . _formHiddenInputs($TVisibleColumn)
@@ -279,19 +281,20 @@ function _mainView($db, $TVisibleColumn, $mode='view', $targetId=NULL) {
  * Calls a specialized callback depending on $colParam['callback'] (or a default one
  * if not set or found) to return a representation of $rawValue depending on $mode:
  *
- * @param mixed $rawValue      A raw value (as returned by the SQL handler)
- * @param array $colParam      Information about the kind of value (date, price, etc.)
- * @param string $mode         'view',   => returns the value for end user display
+ * @param mixed $rawValue A raw value (as returned by the SQL handler)
+ * @param array $colParam Information about the kind of value (date, price, etc.)
+ * @param string $mode 'view',   => returns the value for end user display
  *                             'modify', => returns a form to modify the value
  *                             'new',    => returns a form to put the value in a new record
  *                             'raw',    => does nothing (returns the raw value)
  *                             'text'    => returns a text-only version of the value
  *                                          (for text-only exports etc.)
- * @param string|null $formId  HTML id of the form on which to attach the input in
+ * @param string|null $formId HTML id of the form on which to attach the input in
  *                             'modify' and 'new' modes
  * @return string
  */
-function _getCellContent($rawValue, $colParam, $mode='view', $formId=NULL) {
+function _getCellContent($rawValue, $colParam, $mode = 'view', $formId = NULL)
+{
 	if ($mode === 'raw') return $rawValue;
 	$callback = _cellContentCallbackName($colParam);
 	return call_user_func($callback, $rawValue, $mode, $colParam['name'], $formId);
@@ -304,16 +307,20 @@ function _getCellContent($rawValue, $colParam, $mode='view', $formId=NULL) {
  * @return string
  * @see _getCellContent()
  */
-function _getCellDefault($rawValue, $mode='view', $inputName='', $formId=NULL) {
+function _getCellDefault($rawValue, $mode = 'view', $inputName = '', $formId = NULL)
+{
 	switch ($mode) {
 		case 'view':
 			return dol_escape_htmltag($rawValue);
-		case 'modify': case 'new':
+		case 'modify':
+		case 'new':
 			$inputAttributes = array(
 				'value' => $rawValue,
 				'name' => $inputName,
 			);
-			if ($formId !== NULL) {$inputAttributes['form'] = $formId;}
+			if ($formId !== NULL) {
+				$inputAttributes['form'] = $formId;
+			}
 			return _tagWithAttributes('input', $inputAttributes);
 		case 'raw':
 			return $rawValue;
@@ -335,7 +342,8 @@ function _getCellDefault($rawValue, $mode='view', $inputName='', $formId=NULL) {
  * @return string
  * @see _getCellContent()
  */
-function _getCellDate($rawValue, $mode='view', $inputName='', $formId=NULL) {
+function _getCellDate($rawValue, $mode = 'view', $inputName = '', $formId = NULL)
+{
 	global $db;
 	switch ($mode) {
 		case 'view':
@@ -343,13 +351,16 @@ function _getCellDate($rawValue, $mode='view', $inputName='', $formId=NULL) {
 			$dateFormat = '%d/%m/%Y %H:%M';
 			$dateFormat = '';
 			return dol_print_date($tms, $dateFormat);
-		case 'modify': case 'new':
+		case 'modify':
+		case 'new':
 			$inputAttributes = array(
 				'type' => 'date',
 				'value' => preg_replace('/^(.*?) .*/', '$1', $rawValue),
 				'name' => $inputName,
 			);
-			if ($formId !== NULL) {$inputAttributes['form'] = $formId;}
+			if ($formId !== NULL) {
+				$inputAttributes['form'] = $formId;
+			}
 			return _tagWithAttributes('input', $inputAttributes);
 		case 'raw':
 			return $rawValue;
@@ -362,13 +373,15 @@ function _getCellDate($rawValue, $mode='view', $inputName='', $formId=NULL) {
 			));
 			$y = intval(dol_print_date(dol_now(), '%Y'));
 			$emptyOptParams = array('value' => '');
-			if (empty($rawValue)) { $emptyOptParams['selected'] = 'selected'; }
+			if (empty($rawValue)) {
+				$emptyOptParams['selected'] = 'selected';
+			}
 			$options = array(_tagWithAttributes('option', $emptyOptParams));
-			$options += array_map(function($i) use ($rawValue) {
+			$options += array_map(function ($i) use ($rawValue) {
 				$optParams = array('value' => $i);
 				if ($rawValue == $i) $optParams['selected'] = 'selected';
 				return _tagWithAttributes('option', $optParams) . $i . '</option>';
-			}, range($y-10, $y+1));
+			}, range($y - 10, $y + 1));
 			return $select . join("\n", $options) . '</select>';
 	}
 	return $rawValue;
@@ -381,11 +394,13 @@ function _getCellDate($rawValue, $mode='view', $inputName='', $formId=NULL) {
  * @return string
  * @see _getCellContent()
  */
-function _getCellNumber($rawValue, $mode='view', $inputName='', $formId=NULL) {
+function _getCellNumber($rawValue, $mode = 'view', $inputName = '', $formId = NULL)
+{
 	switch ($mode) {
 		case 'view':
 			return price($rawValue);
-		case 'modify': case 'new':
+		case 'modify':
+		case 'new':
 			$inputAttributes = array(
 				'value' => $rawValue,
 				'name' => $inputName,
@@ -393,7 +408,9 @@ function _getCellNumber($rawValue, $mode='view', $inputName='', $formId=NULL) {
 				'pattern' => '\d+(?:[.,]\d+)?',
 				'required' => 'required',
 			);
-			if ($formId !== NULL) {$inputAttributes['form'] = $formId;}
+			if ($formId !== NULL) {
+				$inputAttributes['form'] = $formId;
+			}
 			return _tagWithAttributes('input', $inputAttributes);
 		case 'raw':
 			return $rawValue;
@@ -414,13 +431,15 @@ function _getCellNumber($rawValue, $mode='view', $inputName='', $formId=NULL) {
  * @param string $inputName
  * @return string
  */
-function _getCellCurrencyCode($rawValue, $mode='view', $inputName='', $formId=NULL) {
+function _getCellCurrencyCode($rawValue, $mode = 'view', $inputName = '', $formId = NULL)
+{
 	global $db, $langs;
 	if ($formId) $formId = htmlspecialchars($formId, ENT_QUOTES);
 	$form = new Form($db);
 	switch ($mode) {
-		case 'view': case 'modify': // 'modify' because the currency code is read-only
-		return $langs->cache_currencies[$rawValue]['label'] . ' (' . $langs->getCurrencySymbol($rawValue) . ')';
+		case 'view':
+		case 'modify': // 'modify' because the currency code is read-only
+			return $langs->cache_currencies[$rawValue]['label'] . ' (' . $langs->getCurrencySymbol($rawValue) . ')';
 		case 'new':
 			$select = $form->selectMultiCurrency($rawValue, $inputName, 1);
 			if ($formId) {
@@ -455,7 +474,8 @@ function _getCellCurrencyCode($rawValue, $mode='view', $inputName='', $formId=NU
  * @param array $colParam
  * @return string
  */
-function _cellContentCallbackName($colParam) {
+function _cellContentCallbackName($colParam)
+{
 	global $langs;
 	$cellContentCallback = '_getCellDefault';
 	// possible override in column definition
@@ -463,8 +483,9 @@ function _cellContentCallbackName($colParam) {
 		$cbName = $colParam['callback'];
 		// mandatory function name prefix: '_getCell' (some day, the callback may come from untrusted input)
 		if (strpos($cbName, '_getCell') !== 0) $cbName = '_getCell' . $cbName;
-		if (function_exists($cbName)) { $cellContentCallback = $cbName; }
-		else {
+		if (function_exists($cbName)) {
+			$cellContentCallback = $cbName;
+		} else {
 			_setEventMessageOnce(
 				$langs->trans('ErrorCallbackNotFound', $cbName),
 				'warnings'
@@ -482,10 +503,11 @@ function _cellContentCallbackName($colParam) {
  *
  *
  * @param string $tagName
- * @param array $TAttribute  [$attrName => $attrVal]
+ * @param array $TAttribute [$attrName => $attrVal]
  * @return string
  */
-function _tagWithAttributes($tagName, $TAttribute) {
+function _tagWithAttributes($tagName, $TAttribute)
+{
 	$selfClosing = in_array($tagName, array('area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr'));
 	$tag = '<' . $tagName;
 	foreach ($TAttribute as $attrName => $attrVal) {
@@ -506,7 +528,8 @@ function _tagWithAttributes($tagName, $TAttribute) {
  * @param string $colSelect
  * @return string
  */
-function _columnAlias($colSelect) {
+function _columnAlias($colSelect)
+{
 	// the regexp replacement does this:
 	//     'table.abcd AS efgh' => 'efgh'
 	// regexp explanation:
@@ -517,7 +540,9 @@ function _columnAlias($colSelect) {
 	//     '([^ `]+)'   => capture 2:     anything that doesn't have a space or a backtick
 	return preg_replace_callback(
 		'/^.*\.`?([^ `]+)`?(?:\s+as\s+`?([^ `]+)`?)?/i',
-		function ($m) { return isset($m[2]) ? $m[2] : $m[1]; },
+		function ($m) {
+			return isset($m[2]) ? $m[2] : $m[1];
+		},
 		$colSelect
 	);
 }
@@ -527,8 +552,11 @@ function _columnAlias($colSelect) {
  * @param $str
  * @return string|string[]|null
  */
-function _camel($str) {
-	return preg_replace_callback('/_(.)?/', function($m) { return ucfirst($m[1]); }, $str);
+function _camel($str)
+{
+	return preg_replace_callback('/_(.)?/', function ($m) {
+		return ucfirst($m[1]);
+	}, $str);
 }
 
 
@@ -536,15 +564,18 @@ function _camel($str) {
  * Default: view all currency rates
  * @param DoliDB $db
  */
-function _actionView($db, $TVisibleColumn) {
+function _actionView($db, $TVisibleColumn)
+{
 	_mainView($db, $TVisibleColumn, 'view', intval(GETPOST('id', 'int')));
 }
 
-function _actionFilter($db, $TVisibleColumn) {
+function _actionFilter($db, $TVisibleColumn)
+{
 	_mainView($db, $TVisibleColumn);
 }
 
-function _actionRemoveFilters($db, $TVisibleColumn) {
+function _actionRemoveFilters($db, $TVisibleColumn)
+{
 	foreach ($TVisibleColumn as $colSelect => &$colParam) {
 		if (isset($colParam['filter_value'])) {
 			unset($colParam['filter_value']);
@@ -558,7 +589,8 @@ function _actionRemoveFilters($db, $TVisibleColumn) {
  * Add a new currency rate
  * @param DoliDB $db
  */
-function _actionAdd($db, $TVisibleColumn) {
+function _actionAdd($db, $TVisibleColumn)
+{
 	global $langs, $conf;
 	$dateSync = GETPOST('date_sync', 'alpha');
 	$rate = GETPOST('rate', 'int');
@@ -585,7 +617,8 @@ function _actionAdd($db, $TVisibleColumn) {
  * Show a currency rate in edit mode
  * @param DoliDB $db
  */
-function _actionModify($db, $TVisibleColumn) {
+function _actionModify($db, $TVisibleColumn)
+{
 	$id = intval(GETPOST('id', 'int'));
 	_mainView($db, $TVisibleColumn, 'modify', $id);
 }
@@ -594,7 +627,8 @@ function _actionModify($db, $TVisibleColumn) {
  * Saves a currency rate
  * @param $db
  */
-function _actionUpdate($db, $TVisibleColumn) {
+function _actionUpdate($db, $TVisibleColumn)
+{
 	global $langs;
 	$id = intval(GETPOST('id', 'int'));
 	$dateSync = GETPOST('date_sync', 'alpha');
@@ -621,7 +655,8 @@ function _actionUpdate($db, $TVisibleColumn) {
  * Show a confirm form prior to deleting a currency rate
  * @param DoliDB $db
  */
-function _actionDelete($db, $TVisibleColumn) {
+function _actionDelete($db, $TVisibleColumn)
+{
 	global $langs;
 	global $delayedhtmlcontent;
 	$id = intval(GETPOST('id', 'int'));
@@ -638,7 +673,7 @@ function _actionDelete($db, $TVisibleColumn) {
 	if (isset($page)) $formParams['page'] = $page;
 	$formParams = http_build_query($formParams);
 	$delayedhtmlcontent .= $form->formconfirm(
-		$_SERVER["PHP_SELF"].'?'.$formParams,
+		$_SERVER["PHP_SELF"] . '?' . $formParams,
 		$langs->trans('DeleteLine'),
 		$langs->trans('ConfirmDeleteLine'),
 		'confirm_delete',
@@ -653,7 +688,8 @@ function _actionDelete($db, $TVisibleColumn) {
  * Delete a currency rate
  * @param DoliDB $db
  */
-function _actionConfirmDelete($db, $TVisibleColumn) {
+function _actionConfirmDelete($db, $TVisibleColumn)
+{
 	global $langs;
 	$id = intval(GETPOST('id', 'int'));
 	if (empty($id)) {
@@ -681,7 +717,8 @@ function _actionConfirmDelete($db, $TVisibleColumn) {
  * @param string $message
  * @param string $level 'errors', 'mesgs', 'warnings'
  */
-function _setEventMessageOnce($message, $level='errors') {
+function _setEventMessageOnce($message, $level = 'errors')
+{
 	if (!in_array($message, $_SESSION['dol_events'][$level])) {
 		setEventMessages($message, array(), $level);
 	}
@@ -692,7 +729,8 @@ function _setEventMessageOnce($message, $level='errors') {
  * @param DoliDB $db
  * @param array $TVisibleColumn
  */
-function _completeColumns($db, &$TVisibleColumn) {
+function _completeColumns($db, &$TVisibleColumn)
+{
 	foreach ($TVisibleColumn as $colSelect => &$colParam) {
 		$colParam['name'] = _columnAlias($colSelect);
 		if (GETPOSTISSET('search_' . $colParam['name'])) {
@@ -719,7 +757,8 @@ function _completeColumns($db, &$TVisibleColumn) {
  * @param array $colParam
  * @return string
  */
-function _getSQLFilterNumber($db, $colParam) {
+function _getSQLFilterNumber($db, $colParam)
+{
 	$filterVal = $colParam['filter_value'];
 	// apply price2num to every part of the string delimited by '<' or '>'
 	$filterVal = join(
@@ -738,12 +777,13 @@ function _getSQLFilterNumber($db, $colParam) {
 	return $sqlFilter;
 }
 
-function _getSQLFilterDate($db, $colParam) {
+function _getSQLFilterDate($db, $colParam)
+{
 	$year = intval($colParam['filter_value']);
-	$yearPlusOne = ($year+1) . '-01-01 00:00:00';
+	$yearPlusOne = ($year + 1) . '-01-01 00:00:00';
 	$year .= '-01-01 00:00:00';
 	$sqlFilter = ' AND (rate.date_sync > "' . $year . '"'
-				. ' AND rate.date_sync < "' . ($yearPlusOne) . '")';
+				 . ' AND rate.date_sync < "' . ($yearPlusOne) . '")';
 	return $sqlFilter;
 }
 
@@ -754,7 +794,8 @@ function _getSQLFilterDate($db, $colParam) {
  * @param $TVisibleColumn
  * @return string
  */
-function _formHiddenInputs($TVisibleColumn) {
+function _formHiddenInputs($TVisibleColumn)
+{
 	$ret = '';
 	foreach ($TVisibleColumn as $colSelect => $colParam) {
 		if (isset($colParam['filter_value'])) {
@@ -766,9 +807,9 @@ function _formHiddenInputs($TVisibleColumn) {
 		}
 	}
 	$ret .= "\n" . _tagWithAttributes('input', array(
-		'type' => 'hidden',
-		'name' => 'token',
-		'value' => newToken()
-	));
+			'type' => 'hidden',
+			'name' => 'token',
+			'value' => newToken()
+		));
 	return $ret;
 }

--- a/htdocs/multicurrency/multicurrency_rates.php
+++ b/htdocs/multicurrency/multicurrency_rates.php
@@ -14,6 +14,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+// FIXME: conflit entre paramètres d'URL et paramètres POST (action=filter vs. action=add)
 
 /**
  *      \file       htdocs/multicurrency/multicurrency_rates.php
@@ -197,8 +198,9 @@ function _mainView($db, $TVisibleColumn, $mode='view', $targetId=NULL) {
 	// entire form is inside cell because HTML does not allow forms inside tables unless they are inside cells
 	echo '<td>'
 		 .'<form method="post" id="form-add-new">'
-		 .'<input type="hidden" name="action" value="add" />'
-		 .'<input class="button" type="submit" value="' . $langs->trans('Add') . '"></a>'
+		 .'<button class="button" name="action" value="add">'
+		 . $langs->trans('Add')
+		 . '</button>'
 		 .'</form>'
 		 .'</td>';
 	echo '</tr>';
@@ -307,9 +309,7 @@ function _getCellDefault($rawValue, $mode='view', $inputName='', $formId=NULL) {
 				'value' => $rawValue,
 				'name' => $inputName,
 			);
-			if ($formId !== NULL) {
-				$inputAttributes['form'] = $formId;
-			}
+			if ($formId !== NULL) {$inputAttributes['form'] = $formId;}
 			return _tagWithAttributes('input', $inputAttributes);
 		case 'raw':
 			return $rawValue;
@@ -345,9 +345,7 @@ function _getCellDate($rawValue, $mode='view', $inputName='', $formId=NULL) {
 				'value' => preg_replace('/^(.*?) .*/', '$1', $rawValue),
 				'name' => $inputName,
 			);
-			if ($formId !== NULL) {
-				$inputAttributes['form'] = $formId;
-			}
+			if ($formId !== NULL) {$inputAttributes['form'] = $formId;}
 			return _tagWithAttributes('input', $inputAttributes);
 		case 'raw':
 			return $rawValue;
@@ -391,9 +389,7 @@ function _getCellNumber($rawValue, $mode='view', $inputName='', $formId=NULL) {
 				'pattern' => '\d+(?:[.,]\d+)?',
 				'required' => 'required',
 			);
-			if ($formId !== NULL) {
-				$inputAttributes['form'] = $formId;
-			}
+			if ($formId !== NULL) {$inputAttributes['form'] = $formId;}
 			return _tagWithAttributes('input', $inputAttributes);
 		case 'raw':
 			return $rawValue;

--- a/htdocs/multicurrency/multicurrency_rates.php
+++ b/htdocs/multicurrency/multicurrency_rates.php
@@ -31,7 +31,13 @@ $res=@include("../main.inc.php");				// For root directory
 require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
 require_once(DOL_DOCUMENT_ROOT."/core/lib/admin.lib.php");
 require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
-$langs->loadLangs(array("errors", "admin", "main", "companies", "resource", "holiday", "accountancy", "hrm", "orders", "contracts", "projects", "propal", "bills", "interventions"));
+dol_include_once('/multicompany/class/actions_multicompany.class.php', 'ActionsMulticompany');
+/** @var Translate $langs */
+$langs->loadLangs(array(
+	"errors",
+	"admin",
+	"main",
+	"multicurrency"));
 
 
 
@@ -41,7 +47,8 @@ if (!$user->admin)
 }
 
 // Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
-$hookmanager->initHooks(array('admin'));
+/** @var HookManager $hookmanager */
+$hookmanager->initHooks(array('multicurrency_rates'));
 
 // Load translation files required by the page
 
@@ -69,66 +76,8 @@ if (empty($page) || $page == -1) { $page = 0; }     // If $page is not defined, 
 $offset = $listlimit * $page;
 $pageprev = $page - 1;
 $pagenext = $page + 1;
+// TODO: sorting, filtering, paginating
 
-
-// This page is a generic page to edit dictionaries
-// Put here declaration of dictionaries properties
-
-// Sort order to show dictionary (0 is space). All other dictionaries (added by modules) will be at end of this.
-$taborder = array(9, 0, 4, 3, 2, 0, 1, 8, 19, 16, 27, 38, 0, 5, 11, 0, 32, 33, 34, 0, 6, 0, 29, 0, 7, 24, 28, 17, 35, 36, 0, 10, 23, 12, 13, 0, 14, 0, 22, 20, 18, 21, 0, 15, 30, 0, 37, 0, 25, 0);
-
-// Name of SQL tables of dictionaries
-$tabname = array();
-$tabname[1] = MAIN_DB_PREFIX."c_forme_juridique";
-
-// Dictionary labels
-$tablib = array();
-$tablib[1] = "DictionaryCompanyJuridicalType";
-
-// Requests to extract data
-$tabsql = array();
-$tabsql[1] = "SELECT f.rowid as rowid, f.code, f.libelle, c.code as country_code, c.label as country, f.active FROM ".MAIN_DB_PREFIX."c_forme_juridique as f, ".MAIN_DB_PREFIX."c_country as c WHERE f.fk_pays=c.rowid";
-
-// Criteria to sort dictionaries
-$tabsqlsort = array();
-$tabsqlsort[1] = "country ASC, code ASC";
-
-// Field names in select result for dictionary display
-$tabfield = array();
-$tabfield[1] = "code,libelle,country";
-
-// Edit field names for editing a record
-$tabfieldvalue = array();
-$tabfieldvalue[1] = "code,libelle,country";
-
-// Field names in the table for inserting a record
-$tabfieldinsert = array();
-$tabfieldinsert[1] = "code,libelle,fk_pays";
-
-// Rowid name of field depending if field is autoincrement on or off..
-// Use "" if id field is "rowid" and has autoincrement on
-// Use "nameoffield" if id field is not "rowid" or has not autoincrement on
-$tabrowid = array();
-$tabrowid[1] = "";
-
-// Condition to show dictionary in setup page
-$tabcond = array();
-$tabcond[1] = (!empty($conf->societe->enabled));
-
-// List of help for fields
-$tabhelp = array();
-$tabhelp[1]  = array('code'=>$langs->trans("EnterAnyCode"));
-// List of check for fields (NOT USED YET)
-$tabfieldcheck = array();
-$tabfieldcheck[1]  = array();
-
-// Defaut sortorder
-if (empty($sortfield))
-{
-	$tmp1 = explode(',', $tabsqlsort[$id]);
-	$tmp2 = explode(' ', $tmp1[0]);
-	$sortfield = preg_replace('/^.*\./', '', $tmp2[0]);
-}
 
 /*
  * Actions
@@ -136,264 +85,6 @@ if (empty($sortfield))
 
 _handleActions($db);
 exit;
-
-/**
- *	Show fields in insert/edit mode
- *
- * 	@param		array		$fieldlist		Array of fields
- * 	@param		Object		$obj			If we show a particular record, obj is filled with record fields
- *  @param		string		$tabname		Name of SQL table
- *  @param		string		$context		'add'=Output field for the "add form", 'edit'=Output field for the "edit form", 'hide'=Output field for the "add form" but we dont want it to be rendered
- *	@return		string						'' or value of entity into table
- */
-function fieldList($fieldlist, $obj = '', $tabname = '', $context = '')
-{
-	global $conf, $langs, $db, $mysoc;
-	global $form;
-	global $region_id;
-	global $elementList, $sourceList, $localtax_typeList;
-
-	$formadmin = new FormAdmin($db);
-	$formcompany = new FormCompany($db);
-	$formaccounting = new FormAccounting($db);
-
-	$withentity = '';
-
-	foreach ($fieldlist as $field => $value)
-	{
-		if ($fieldlist[$field] == 'entity') {
-			$withentity = $obj->{$fieldlist[$field]};
-			continue;
-		}
-
-		if (in_array($fieldlist[$field], array('code', 'libelle', 'type')) && $tabname == MAIN_DB_PREFIX."c_actioncomm" && in_array($obj->type, array('system', 'systemauto')))
-		{
-			$hidden = (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'');
-			print '<td>';
-			print '<input type="hidden" name="'.$fieldlist[$field].'" value="'.$hidden.'">';
-			print $langs->trans($hidden);
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'country')
-		{
-			if (in_array('region_id', $fieldlist))
-			{
-				print '<td>';
-				print '</td>';
-				continue;
-			}	// For state page, we do not show the country input (we link to region, not country)
-			print '<td>';
-			$fieldname = 'country';
-			print $form->select_country((!empty($obj->country_code) ? $obj->country_code : (!empty($obj->country) ? $obj->country : '')), $fieldname, '', 28, 'maxwidth150 maxwidthonsmartphone');
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'country_id')
-		{
-			if (!in_array('country', $fieldlist))	// If there is already a field country, we don't show country_id (avoid duplicate)
-			{
-				$country_id = (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]} : 0);
-				print '<td class="tdoverflowmax100">';
-				print '<input type="hidden" name="'.$fieldlist[$field].'" value="'.$country_id.'">';
-				print '</td>';
-			}
-		}
-		elseif ($fieldlist[$field] == 'region')
-		{
-			print '<td>';
-			$formcompany->select_region($region_id, 'region');
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'region_id')
-		{
-			$region_id = (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:0);
-			print '<td>';
-			print '<input type="hidden" name="'.$fieldlist[$field].'" value="'.$region_id.'">';
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'lang')
-		{
-			print '<td>';
-			print $formadmin->select_language($conf->global->MAIN_LANG_DEFAULT, 'lang');
-			print '</td>';
-		}
-		// The type of the element (for contact types)
-		elseif ($fieldlist[$field] == 'element')
-		{
-			print '<td>';
-			print $form->selectarray('element', $elementList, (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''));
-			print '</td>';
-		}
-		// The source of the element (for contact types)
-		elseif ($fieldlist[$field] == 'source')
-		{
-			print '<td>';
-			print $form->selectarray('source', $sourceList, (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''));
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'private')
-		{
-			print '<td>';
-			print $form->selectyesno("private", (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''));
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'type' && $tabname == MAIN_DB_PREFIX."c_actioncomm")
-		{
-			$type = (!empty($obj->type) ? $obj->type : 'user'); // Check if type is different of 'user' (external module)
-			print '<td>';
-			print $type.'<input type="hidden" name="type" value="'.$type.'">';
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'type' && $tabname == MAIN_DB_PREFIX.'c_paiement')
-		{
-			print '<td>';
-			$select_list = array(0=>$langs->trans('PaymentTypeCustomer'), 1=>$langs->trans('PaymentTypeSupplier'), 2=>$langs->trans('PaymentTypeBoth'));
-			print $form->selectarray($fieldlist[$field], $select_list, (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'2'));
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'recuperableonly' || $fieldlist[$field] == 'type_cdr' || $fieldlist[$field] == 'deductible' || $fieldlist[$field] == 'category_type') {
-			if ($fieldlist[$field] == 'type_cdr') print '<td class="center">';
-			else print '<td>';
-			if ($fieldlist[$field] == 'type_cdr') {
-				print $form->selectarray($fieldlist[$field], array(0=>$langs->trans('None'), 1=>$langs->trans('AtEndOfMonth'), 2=>$langs->trans('CurrentNext')), (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''));
-			} else {
-				print $form->selectyesno($fieldlist[$field], (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''), 1);
-			}
-			print '</td>';
-		}
-		elseif (in_array($fieldlist[$field], array('nbjour', 'decalage', 'taux', 'localtax1', 'localtax2'))) {
-			$class = "left";
-			if (in_array($fieldlist[$field], array('taux', 'localtax1', 'localtax2'))) $class = "center"; // Fields aligned on right
-			print '<td class="'.$class.'">';
-			print '<input type="text" class="flat" value="'.(isset($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]} : '').'" size="3" name="'.$fieldlist[$field].'">';
-			print '</td>';
-		}
-		elseif (in_array($fieldlist[$field], array('libelle_facture'))) {
-			print '<td>';
-			$transfound = 0;
-			$transkey = '';
-			// Special case for labels
-			if ($tabname == MAIN_DB_PREFIX.'c_payment_term')
-			{
-				$langs->load("bills");
-				$transkey = "PaymentCondition".strtoupper($obj->code);
-				if ($langs->trans($transkey) != $transkey)
-				{
-					$transfound = 1;
-					print $form->textwithpicto($langs->trans($transkey), $langs->trans("GoIntoTranslationMenuToChangeThis"));
-				}
-			}
-			if (!$transfound)
-			{
-				print '<textarea cols="30" rows="'.ROWS_2.'" class="flat" name="'.$fieldlist[$field].'">'.(!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'').'</textarea>';
-			}
-			else {
-				print '<input type="hidden" name="'.$fieldlist[$field].'" value="'.$transkey.'">';
-			}
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'price' || preg_match('/^amount/i', $fieldlist[$field])) {
-			print '<td><input type="text" class="flat minwidth75" value="'.price((!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'')).'" name="'.$fieldlist[$field].'"></td>';
-		}
-		elseif ($fieldlist[$field] == 'code' && isset($obj->{$fieldlist[$field]})) {
-			print '<td><input type="text" class="flat minwidth75 maxwidth100" value="'.(!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'').'" name="'.$fieldlist[$field].'"></td>';
-		}
-		elseif ($fieldlist[$field] == 'unit') {
-			print '<td>';
-			$units = array(
-				'mm' => $langs->trans('SizeUnitmm'),
-				'cm' => $langs->trans('SizeUnitcm'),
-				'point' => $langs->trans('SizeUnitpoint'),
-				'inch' => $langs->trans('SizeUnitinch')
-			);
-			print $form->selectarray('unit', $units, (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''), 0, 0, 0);
-			print '</td>';
-		}
-		// Le type de taxe locale
-		elseif ($fieldlist[$field] == 'localtax1_type' || $fieldlist[$field] == 'localtax2_type')
-		{
-			print '<td class="center">';
-			print $form->selectarray($fieldlist[$field], $localtax_typeList, (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''));
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'accountancy_code' || $fieldlist[$field] == 'accountancy_code_sell' || $fieldlist[$field] == 'accountancy_code_buy')
-		{
-			print '<td>';
-			if (!empty($conf->accounting->enabled))
-			{
-				$fieldname = $fieldlist[$field];
-				$accountancy_account = (!empty($obj->$fieldname) ? $obj->$fieldname : 0);
-				print $formaccounting->select_account($accountancy_account, '.'.$fieldlist[$field], 1, '', 1, 1, 'maxwidth200 maxwidthonsmartphone');
-			}
-			else
-			{
-				$fieldname = $fieldlist[$field];
-				print '<input type="text" size="10" class="flat" value="'.(isset($obj->$fieldname) ? $obj->$fieldname : '').'" name="'.$fieldlist[$field].'">';
-			}
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'fk_tva')
-		{
-			print '<td>';
-			print $form->load_tva('fk_tva', $obj->taux, $mysoc, new Societe($db), 0, 0, '', false, -1);
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'fk_c_exp_tax_cat')
-		{
-			print '<td>';
-			print $form->selectExpenseCategories($obj->fk_c_exp_tax_cat);
-			print '</td>';
-		}
-		elseif ($fieldlist[$field] == 'fk_range')
-		{
-			print '<td>';
-			print $form->selectExpenseRanges($obj->fk_range);
-			print '</td>';
-		}
-		else
-		{
-			$fieldValue = isset($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'';
-
-			if ($fieldlist[$field] == 'sortorder')
-			{
-				$fieldlist[$field] = 'position';
-			}
-
-			$classtd = ''; $class = '';
-			if ($fieldlist[$field] == 'code') $class = 'maxwidth100';
-			if (in_array($fieldlist[$field], array('dayrule', 'day', 'month', 'year', 'pos', 'use_default', 'affect', 'delay', 'position', 'sortorder', 'sens', 'category_type'))) $class = 'maxwidth50';
-			if (in_array($fieldlist[$field], array('libelle', 'label', 'tracking'))) $class = 'quatrevingtpercent';
-			print '<td class="'.$classtd.'">';
-			$transfound = 0;
-			$transkey = '';
-			if (in_array($fieldlist[$field], array('label', 'libelle')))		// For label
-			{
-				// Special case for labels
-				if ($tabname == MAIN_DB_PREFIX.'c_civility') {
-					$transkey = "Civility".strtoupper($obj->code);
-				}
-				if ($tabname == MAIN_DB_PREFIX.'c_payment_term') {
-					$langs->load("bills");
-					$transkey = "PaymentConditionShort".strtoupper($obj->code);
-				}
-				if ($transkey && $langs->trans($transkey) != $transkey)
-				{
-					$transfound = 1;
-					print $form->textwithpicto($langs->trans($transkey), $langs->trans("GoIntoTranslationMenuToChangeThis"));
-				}
-			}
-			if (!$transfound)
-			{
-				print '<input type="text" class="flat'.($class ? ' '.$class : '').'" value="'.dol_escape_htmltag($fieldValue).'" name="'.$fieldlist[$field].'">';
-			}
-			else {
-				print '<input type="hidden" name="'.$fieldlist[$field].'" value="'.$transkey.'">';
-			}
-			print '</td>';
-		}
-	}
-
-	return $withentity;
-}
 
 function _handleActions($db) {
 	$action = GETPOST('action', 'alpha');
@@ -408,88 +99,122 @@ function _handleActions($db) {
 	call_user_func($callbackName, $db);
 }
 
-function _actionAdd($db) {
-
-}
-
-function _actionModify($db) {
-	$id = GETPOST('id', 'int');
-	_showDictionary($db, 'modify', $id);
-}
-
-function _actionView($db) {
-	_showDictionary($db, 'view', intval(GETPOST('id', 'int'))));
-}
-
-function _actionDelete($db) {
+/**
+ * @param DoliDB $db
+ * @param string $mode
+ * @param int|null $targetId ID of the row targeted for edition, deletion, etc.
+ */
+function _mainView($db, $mode='view', $targetId=NULL) {
 	global $langs;
-	global $delayedhtmlcontent;
-	$form = new Form($db);
-	$delayedhtmlcontent .= $form->formconfirm(
-		$_SERVER["PHP_SELF"].'?'.($page ? 'page='.$page.'&' : '').$paramwithsearch,
-		$langs->trans('DeleteLine'),
-		$langs->trans('ConfirmDeleteLine'),
-		'confirm_delete',
-		'',
-		0,
-		1
-	);
-	_showDictionary($db, 'view', intval(GETPOST('id', 'int')));
-}
-
-function _actionConfirmDelete($db) {
-	$id = GETPOST('id', 'int');
-	$sql = 'DELETE FROM ' . MAIN_DB_PREFIX . 'multicurrency_rate'
-		   .' WHERE rowid = ' . intval($id);
-
-	_showDictionary($db, 'view');
-}
-
-function _showDictionary($db, $mode='view', $id=NULL) {
-	global $langs;
-	$form = new Form($db);
-	$formadmin = new FormAdmin($db);
 	$title = $langs->trans('CurrencyRateSetup');
 	$limit = 123;
 
+	// column definition
 	$TVisibleColumn = array(
-		'rate.date_sync' => array('Date'),
-		'rate.rate' => array('Number'),
-		'currency.code' => array('CurrencyCode'),
-		'rate.entity' => array(),
+		'rate.date_sync'
+			=> array('callback' => 'Date'),
+		'rate.rate'
+			=> array('callback' => 'Number'),
+		'currency.code'
+			=> array('callback' => 'CurrencyCode'),
+//		'rate.entity'
+//			=> array('callback' => 'Entity'),
 	);
-	foreach ($TVisibleColumn as $colSelect => &$colParam) {
-		$colParam['name'] = _columnAlias($colSelect);
-	}
+	foreach ($TVisibleColumn as $colSelect => &$colParam) { $colParam['name'] = _columnAlias($colSelect); }
 	unset($colParam);
 
-	$sql = 'SELECT rate.rowid, ' . join(', ', array_keys($TVisibleColumn)) . ' FROM ' . MAIN_DB_PREFIX . 'multicurrency_rate rate'
-		   . ' LEFT JOIN ' . MAIN_DB_PREFIX . 'multicurrency currency ON rate.fk_multicurrency = currency.rowid'
-		   . ' WHERE 1 = 1'
-		   . ' LIMIT ' . intval($limit);
+	$sql = /** @lang SQL */
+		'SELECT rate.rowid, ' . join(', ', array_keys($TVisibleColumn)) . ' FROM ' . MAIN_DB_PREFIX . 'multicurrency_rate rate'
+		. ' LEFT JOIN ' . MAIN_DB_PREFIX . 'multicurrency currency ON rate.fk_multicurrency = currency.rowid'
+		. ' WHERE rate.entity IN (' . getEntity('multicurrency') . ')'
+		. ' ORDER BY rate.date_sync DESC'
+		. ' LIMIT ' . intval($limit);
 	$resql = $db->query($sql);
 	if (!$resql) {
-		llxFooter();
-		return;
+		setEventMessages($db->lasterror, array(), 'errors');
+		$num_rows = 0;
+	} else {
+		$num_rows = $db->num_rows($resql);
 	}
-	$num_rows = $db->num_rows($resql);
 
 	llxHeader();
-	echo load_fiche_titre($title, $linkback, $titlepicto);
+	echo load_fiche_titre($title);
+
+	echo '<style>'
+		 . 'button.like-link {'
+		 . '  border: none;'
+		 . '  padding: 0;'
+		 . '  background: inherit;'
+		 . '  cursor: pointer;'
+		 .'}'
+		 .'col.small-col {'
+		 . '  width: 10%'
+		 .'}'
+		 . '</style>';
 
 	echo '<table class="noborder centpercent">';
-	echo '<thead>';
-	echo '<tr>';
+	echo '<colgroup>'
+		 . '<col span="' . count($TVisibleColumn) . '">'
+		 . '<col class="small-col" span="1">'
+		 . '</colgroup>';
 
-	// titres
+
+	// En-têtes de colonnes
+	echo '<thead>';
+	echo '<tr id="title-row">';
 	foreach ($TVisibleColumn as $colSelect => $colParam) {
-		echo '<th>';
-		echo $langs->trans('multicurrencyColumn' . _camel(ucfirst($colParam['name'])));
+		echo '<th class="' . $colParam['name'] . '">';
+		echo $langs->trans('Multicurrency' . _camel(ucfirst($colParam['name'])));
 		echo '</th>';
 	}
-	echo '<th></th>';
+	echo '<th class="actions"></th>';
+	echo '</tr>';
+
+	// Formulaire des filtres de recherche
+	echo '<tr id="filter-row">';
+	foreach ($TVisibleColumn as $colSelect => $colParam) {
+		echo '<td class="' . $colParam['name'] . '">';
+		echo _getCellContent(
+			GETPOST('search_' . $colParam['name']),
+			$colParam,
+			'search',
+			'form-filter'
+		);
+		echo '</td>';
+	}
+	echo '<td class="actions">'
+		 . '<form method="get" id="form-filter" action="' . $_SERVER["PHP_SELF"] . '">'
+		 . '<button class="like-link" name="action" value="search">'
+		 . '<span class="fa fa-search" >&nbsp;</span>'
+		 . '</button>'
+		 . '<button class="like-link" name="action" value="remove_filters">'
+		 . '<span class="fa fa-remove" >&nbsp;</span>'
+		 . '</button>'
+		 . '</form>'
+		 . '</td>';
 	echo '</tr>';
 	echo '</thead>';
+
+	// formulaire d'ajout ('new')
+	echo '<tbody>';
+	echo '<tr id="row-add-new">';
+	foreach ($TVisibleColumn as $colSelect => $colParam) {
+		echo '<td class="' . $colParam['name'] . '">';
+		// show an empty input
+		echo _getCellContent('', $colParam, 'new', 'form-add-new');
+		echo '</td>';
+	}
+	// entire form is inside cell because HTML does not allow forms inside tables unless they are inside cells
+	echo '<td>'
+		 .'<form method="post" id="form-add-new">'
+		 .'<input type="hidden" name="action" value="add" />'
+		 .'<input class="button" type="submit" value="' . $langs->trans('Add') . '"></a>'
+		 .'</form>'
+		 .'</td>';
+	echo '</tr>';
+	echo '</tbody>';
+
+	// lignes
 	echo '<tbody>';
 	if (!$num_rows) {
 		echo '<tr>';
@@ -500,42 +225,184 @@ function _showDictionary($db, $mode='view', $id=NULL) {
 	}
 	for ($i = 0; $i < $num_rows; $i++) {
 		$obj = $db->fetch_object($resql);
+		$objId = intval($obj->rowid);
+		$row_is_in_edit_mode = ($mode === 'modify' && $objId === $targetId);
+		$form_update_name = "form-update-" . $objId;
 		if (!$obj) { break; }
-		echo '<tr data-id="' . intval($obj->rowid) . '">';
+		echo '<tr id="row-' . intval($obj->rowid) . '">';
 		foreach ($TVisibleColumn as $colSelect => $colParam) {
 			$rawValue = $obj->{$colParam['name']};
-
-			// default callback for how to display the raw value
-			$cellContentCallback = '_getCellDefault';
-
-			// possible override in column definition
-			if (isset($colParam['callback'])) {
-				$cbName = $colParam['callback'];
-				// mandatory function name prefix: '_getCell' (some day, the callback may come from untrusted input)
-				if (strpos($cbName, '_getCell') !== 0) $cbName = '_getCell' . $cbName;
-				if (function_exists($cbName)) { $cellContentCallback = $cbName; }
-			}
-
-			if ($mode === 'modify' && $obj->rowid === $id) {
-				$cellContent = call_user_func($cellContentCallback, $rawValue, 'modify', $colParam['name']);
-			} else {
-				$cellContent = call_user_func($cellContentCallback, $rawValue, 'view', $colParam['name']);
-			}
-			echo '<td>' . $cellContent . '</td>';
+			$displayMode = 'view';
+			if ($row_is_in_edit_mode) { $displayMode = 'modify'; }
+			$cellContent = _getCellContent($rawValue, $colParam, $displayMode, $form_update_name);
+			echo '<td class="' . $colParam['name'] . '">' . $cellContent . '</td>';
 		}
 
-		echo '<td>'
-			 . '<a href="?action=modify&id=' . intval($obj->rowid) . '">' . img_picto('edit', 'edit') . '</a>'
-			 . '<a href="?action=delete&id=' . intval($obj->rowid) . '">' . img_picto('delete', 'delete') . '</a>'
-			 . '</td>';
+		echo '<td class="actions">';
+		// save form (for the row in edit mode)
+		if ($row_is_in_edit_mode) {
+			echo '<form method="post" action="' . $_SERVER['PHP_SELF'] . '" id="' . $form_update_name . '" style="display: inline;">'
+				 . '<input type="hidden" name="id" value="' . $objId . '">'
+				 . '<input type="hidden" name="action" value="update">'
+				 . '<input type="submit" class="button" value="'
+				 . htmlspecialchars($langs->trans('Save'), ENT_QUOTES)
+				 . '" />'
+				 . '</form>';
+		}
+
+		// edit + delete buttons (for rows not in edit mode)
+		else {
+			echo '<form method="post" action="' . $_SERVER['PHP_SELF'] . '" id="form-edit-' . $objId . '" style="display: inline;">'
+				 . '<input type="hidden" name="id" value="' . $objId . '">'
+				 . '<input type="hidden" name="action" value="modify">'
+				 . '<button class="like-link">'
+				 . img_picto('edit', 'edit')
+				 . '</button>'
+				 . '</form>';
+			echo '<form method="post" action="' . $_SERVER['PHP_SELF'] . '" id="form-delete-' . $objId . '" style="display: inline;">'
+				 . '<input type="hidden" name="id" value="' . $objId . '">'
+				 . '<input type="hidden" name="action" value="delete">'
+				 . '<button class="like-link">'
+				 . img_picto('delete', 'delete')
+				 . '</button>'
+				 . '</form>';
+		}
+		echo '</td>';
 		echo '</tr>';
 	}
 	echo '</tbody>';
 	echo '</table>';
 
+
 	// End of page
 	llxFooter();
 	$db->close();
+}
+
+/**
+ * Calls a specialized callback depending on $colParam['callback'] (or a default one
+ * if not set or found) to return a representation of $rawValue depending on $mode:
+ *
+ * @param mixed $rawValue      A raw value (as returned by the SQL handler)
+ * @param array $colParam      Information about the kind of value (date, price, etc.)
+ * @param string $mode         'view',   => returns the value for end user display
+ *                             'modify', => returns a form to modify the value
+ *                             'new',    => returns a form to put the value in a new record
+ *                             'raw',    => does nothing (returns the raw value)
+ *                             'text'    => returns a text-only version of the value
+ *                                          (for text-only exports etc.)
+ * @param string|null $formId  HTML id of the form on which to attach the input in
+ *                             'modify' and 'new' modes
+ * @return string
+ */
+function _getCellContent($rawValue, $colParam, $mode='view', $formId=NULL) {
+	if ($mode === 'raw') return $rawValue;
+	$callback = _cellContentCallbackName($colParam);
+	return call_user_func($callback, $rawValue, $mode, $colParam['name'], $formId);
+}
+
+/**
+ * @param $rawValue
+ * @param string $mode
+ * @param string $inputName
+ * @return string
+ * @see _getCellContent()
+ */
+function _getCellDefault($rawValue, $mode='view', $inputName='', $formId=NULL) {
+	switch ($mode) {
+		case 'view':
+			return dol_escape_htmltag($rawValue);
+		case 'modify': case 'new':
+			$inputAttributes = array(
+				'value' => $rawValue,
+				'name' => $inputName,
+			);
+			if ($formId !== NULL) {
+				$inputAttributes['form'] = $formId;
+			}
+			return _tagWithAttributes('input', $inputAttributes);
+		case 'raw':
+			return $rawValue;
+		case 'text':
+			return strip_tags($rawValue);
+		case 'search':
+			return '<input name="search_' . $inputName . '" value="'
+				   . htmlspecialchars(GETPOST('search_' . $inputName), ENT_QUOTES)
+				   . '" />';
+	}
+	return $rawValue;
+}
+
+/**
+ * @param $rawValue
+ * @param string $mode
+ * @param string $inputName
+ * @return string
+ * @see _getCellContent()
+ */
+function _getCellDate($rawValue, $mode='view', $inputName='', $formId=NULL) {
+	global $db;
+	switch ($mode) {
+		case 'view':
+			$tms = $db->jdate($rawValue);
+			$dateFormat = '%d/%m/%Y %H:%M';
+			$dateFormat = '';
+			return dol_print_date($tms, $dateFormat);
+		case 'modify': case 'new':
+			$inputAttributes = array(
+				'type' => 'date',
+				'value' => preg_replace('/^(.*?) .*/', '$1', $rawValue),
+				'name' => $inputName,
+			);
+			if ($formId !== NULL) {
+				$inputAttributes['form'] = $formId;
+			}
+			return _tagWithAttributes('input', $inputAttributes);
+		case 'raw':
+			return $rawValue;
+		case 'text':
+			return strip_tags($rawValue);
+		case 'search':
+			return '<input name="search_' . $inputName . '" value="'
+				   . htmlspecialchars(GETPOST('search_' . $inputName), ENT_QUOTES)
+				   . '" />';
+	}
+	return $rawValue;
+}
+
+/**
+ * @param $rawValue
+ * @param string $mode
+ * @param string $inputName
+ * @return string
+ * @see _getCellContent()
+ */
+function _getCellNumber($rawValue, $mode='view', $inputName='', $formId=NULL) {
+	switch ($mode) {
+		case 'view':
+			return price($rawValue);
+		case 'modify': case 'new':
+			$inputAttributes = array(
+				'value' => $rawValue,
+				'name' => $inputName,
+				'placeholder' => '0,00',
+				'pattern' => '\d+(?:[.,]\d+)?',
+				'required' => 'required',
+			);
+			if ($formId !== NULL) {
+				$inputAttributes['form'] = $formId;
+			}
+			return _tagWithAttributes('input', $inputAttributes);
+		case 'raw':
+			return $rawValue;
+		case 'text':
+			return strip_tags($rawValue);
+		case 'search':
+			return '<input name="search_' . $inputName . '" value="'
+				   . htmlspecialchars(GETPOST('search_' . $inputName), ENT_QUOTES)
+				   . '" />';
+	}
+	return $rawValue;
 }
 
 /**
@@ -544,15 +411,110 @@ function _showDictionary($db, $mode='view', $id=NULL) {
  * @param string $inputName
  * @return string
  */
-function _getcellDefault($rawValue, $mode='view', $inputName='') {
-	if ($mode === 'view') {
-		return dol_escape_htmltag($rawValue);
-	} elseif ($mode === 'modify') {
-		return '<input value="'
-			   . htmlspecialchars($rawValue, ENT_QUOTES)
-			   . '" name="' . $inputName
-			   . '" />';
+function _getCellCurrencyCode($rawValue, $mode='view', $inputName='', $formId=NULL) {
+	global $db, $langs;
+	$form = new Form($db);
+	switch ($mode) {
+		case 'view': case 'modify': // 'modify' because the currency code is read-only
+		return $langs->cache_currencies[$rawValue]['label'] . ' (' . $langs->getCurrencySymbol($rawValue) . ')';
+		case 'new':
+			$select = $form->selectMultiCurrency($rawValue, $inputName, 1);
+			if ($formId) {
+				// add form attribute to the output of selectCurrency
+				$select = preg_replace(
+					'/^<select /i',
+					'<select form="' . htmlspecialchars($formId, ENT_QUOTES) . '" ',
+					$select
+				);
+			}
+			return $select;
+		case 'raw':
+			return $rawValue;
+		case 'text':
+			return strip_tags($rawValue);
+		case 'search':
+			return '<input name="search_' . $inputName . '" value="'
+				   . htmlspecialchars(GETPOST('search_' . $inputName), ENT_QUOTES)
+				   . '"'
+				   . ' />';
 	}
+	return $rawValue;
+}
+
+///**
+// * @param $rawValue
+// * @param string $mode
+// * @param string $inputName
+// * @return string
+// */
+//function _getCellEntity($rawValue, $mode='view', $inputName='', $formId=NULL) {
+//	global $db, $langs;
+//	$form = new Form($db);
+//	switch ($mode) {
+//		case 'view': case 'modify': // 'modify' because the entity is read-only
+//		return intval($rawValue);
+//		case 'new':
+//			$mc = new ActionsMulticompany($db);
+//			$select = $mc->select_entities($rawValue, $inputName);
+//			if ($formId) {
+//				// add form attribute to the output of selectCurrency
+//				$select = preg_replace(
+//					'/^<select /i',
+//					'<select form="' . htmlspecialchars($formId, ENT_QUOTES) . '" ',
+//					$select
+//				);
+//			}
+//			return $select;
+//		case 'raw':
+//			return $rawValue;
+//		case 'text':
+//			return strip_tags($rawValue);
+//	}
+//	return $rawValue;
+//}
+
+/**
+ * @param array $colParam
+ * @return string
+ */
+function _cellContentCallbackName($colParam) {
+	global $langs;
+	$cellContentCallback = '_getCellDefault';
+	// possible override in column definition
+	if (isset($colParam['callback'])) {
+		$cbName = $colParam['callback'];
+		// mandatory function name prefix: '_getCell' (some day, the callback may come from untrusted input)
+		if (strpos($cbName, '_getCell') !== 0) $cbName = '_getCell' . $cbName;
+		if (function_exists($cbName)) { $cellContentCallback = $cbName; }
+		else {
+			_setEventMessageOnce(
+				$langs->trans('ErrorCallbackNotFound', $cbName),
+				'warnings'
+			);
+		}
+	}
+	return $cellContentCallback;
+}
+
+/**
+ * Returns an opening (or self-closing) tag with the (escaped) requested attributes
+ *
+ * Example: _tagWithAttributes('input', ['name' => 'test', 'value' => '"hello"'])
+ *          => '<input name="test" value="&quot;nothing&quot;" />'
+ *
+ *
+ * @param string $tagName
+ * @param array $TAttribute  [$attrName => $attrVal]
+ * @return string
+ */
+function _tagWithAttributes($tagName, $TAttribute) {
+	$selfClosing = in_array($tagName, array('area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input', 'link', 'meta', 'param', 'source', 'track', 'wbr'));
+	$tag = '<' . $tagName;
+	foreach ($TAttribute as $attrName => $attrVal) {
+		$tag .= ' ' . $attrName . '="' . str_replace("\n", "&#10;", htmlspecialchars($attrVal, ENT_QUOTES)) . '"';
+	}
+	$tag .= $selfClosing ? ' />' : ' >';
+	return $tag;
 }
 
 /**
@@ -589,4 +551,138 @@ function _columnAlias($colSelect) {
  */
 function _camel($str) {
 	return preg_replace_callback('/_(.)?/', function($m) { return ucfirst($m[1]); }, $str);
+}
+
+
+/**
+ * Default: view all currency rates
+ * @param DoliDB $db
+ */
+function _actionView($db) {
+	_mainView($db, 'view', intval(GETPOST('id', 'int')));
+}
+
+/**
+ * Add a new currency rate
+ * @param DoliDB $db
+ */
+function _actionAdd($db) {
+	global $langs, $conf;
+	$dateSync = GETPOST('date_sync', 'alpha');
+	$rate = GETPOST('rate', 'int');
+	$code = GETPOST('code', 'aZ09');
+	$entity = intval($conf->entity);
+	$sql = 'INSERT INTO ' . MAIN_DB_PREFIX . 'multicurrency_rate (`date_sync`, `rate`, `fk_multicurrency`, `entity`)'
+		   . ' VALUES ('
+		   . ' "' . $db->escape($dateSync) . '"'
+		   . ' ,"' . $db->escape($rate) . '"'
+		   . ' , (SELECT rowid FROM llx_multicurrency WHERE code = "'. $db->escape($code) . '" AND entity IN ('. getEntity('multicurrency') .') LIMIT 1)'
+		   . ' ,"' . $db->escape($entity) . '"'
+		   .')';
+	$resql = $db->query($sql);
+	if (!$resql) {
+		setEventMessages($langs->trans('TODOSaveFailed'), array(), 'errors');
+	}
+	_mainView($db, 'view');
+}
+
+/**
+ * Show a currency rate in edit mode
+ * @param DoliDB $db
+ */
+function _actionModify($db) {
+	$id = intval(GETPOST('id', 'int'));
+	_mainView($db, 'modify', $id);
+}
+
+/**
+ * Saves a currency rate
+ * @param $db
+ */
+function _actionUpdate($db) {
+	global $langs;
+	$id = intval(GETPOST('id', 'int'));
+	$dateSync = GETPOST('date_sync', 'alpha');
+	$rate = GETPOST('rate', 'int');
+	$date = date_parse($dateSync);
+	$date = dol_mktime(
+		$date['hour'],
+		$date['minute'],
+		$date['second'],
+		$date['month'],
+		$date['day'],
+		$date['year']
+	);
+	$sql = /** @lang SQL */
+		'UPDATE ' . MAIN_DB_PREFIX . 'multicurrency_rate SET'
+		. '   date_sync = "' . $db->idate($date) . '",'
+		. '   rate = "' . price2num($rate) . '"'
+		. ' WHERE rowid = ' . $id;
+	$resql = $db->query($sql);
+	if (!$resql) {
+		setEventMessages($langs->trans($db->lasterror), array(), 'errors');
+	} else {
+		setEventMessages($langs->trans('Saved'), array(), 'mesgs');
+	}
+	_mainView($db);
+}
+
+/**
+ * Show a confirm form prior to deleting a currency rate
+ * @param DoliDB $db
+ */
+function _actionDelete($db) {
+	global $langs;
+	global $delayedhtmlcontent;
+	$id = intval(GETPOST('id', 'int'));
+	$form = new Form($db);
+	$formParams = array(
+		'id' => $id,
+	);
+	if (isset($page)) $formParams['page'] = $page;
+	$formParams = http_build_query($formParams);
+	$delayedhtmlcontent .= $form->formconfirm(
+		$_SERVER["PHP_SELF"].'?'.$formParams,
+		$langs->trans('DeleteLine'),
+		$langs->trans('ConfirmDeleteLine'),
+		'confirm_delete',
+		'',
+		0,
+		1
+	);
+	_mainView($db, 'view');
+}
+
+/**
+ * Delete a currency rate
+ * @param DoliDB $db
+ */
+function _actionConfirmDelete($db) {
+	global $langs;
+	$id = intval(GETPOST('id', 'int'));
+	if ($id === 0) {
+		setEventMessages($langs->trans('WrongID'), array(), 'errors');
+	} else {
+		$sql = 'DELETE FROM ' . MAIN_DB_PREFIX . 'multicurrency_rate'
+			. ' WHERE rowid = ' . $id;
+		$resql = $db->query($sql);
+		if (!$resql) {
+			setEventMessages($db->lasterror, array(), 'errors');
+		} else {
+			setEventMessages($langs->trans('MulticurrencyRateDeleted'), array(), 'mesgs');
+		}
+	}
+	_mainView($db, 'view');
+}
+
+/**
+ * Calls setEventMessages only if $message is not already stored for display
+ *
+ * @param string $message
+ * @param string $level 'errors', 'mesgs', 'warnings'
+ */
+function _setEventMessageOnce($message, $level='errors') {
+	if (!in_array($message, $_SESSION['dol_events'][$level])) {
+		setEventMessages($message, array(), $level);
+	}
 }

--- a/htdocs/multicurrency/multicurrency_rates.php
+++ b/htdocs/multicurrency/multicurrency_rates.php
@@ -628,6 +628,7 @@ function _actionDelete($db, $TVisibleColumn) {
 	$form = new Form($db);
 	$formParams = array(
 		'id' => $id,
+		'token' => newToken(),
 	);
 	foreach ($TVisibleColumn as $colSelect => $colParam) {
 		if (isset($colParam['filter_value'])) {

--- a/htdocs/multicurrency/multicurrency_rates.php
+++ b/htdocs/multicurrency/multicurrency_rates.php
@@ -1,0 +1,592 @@
+<?php
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+/**
+ *      \file       htdocs/multicurrency/multicurrency_rates.php
+ *		\ingroup    multicurrency
+ *		\brief      Shows an exchange rate editor
+ */
+
+$res=@include("../main.inc.php");				// For root directory
+
+/**
+ * @var User $user
+ * @var DoliDB $db
+ */
+
+require_once DOL_DOCUMENT_ROOT.'/core/class/html.formadmin.class.php';
+require_once(DOL_DOCUMENT_ROOT."/core/lib/admin.lib.php");
+require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
+$langs->loadLangs(array("errors", "admin", "main", "companies", "resource", "holiday", "accountancy", "hrm", "orders", "contracts", "projects", "propal", "bills", "interventions"));
+
+
+
+if (!$user->admin)
+{
+	accessforbidden();
+}
+
+// Initialize technical object to manage hooks of page. Note that conf->hooks_modules contains array of hook context
+$hookmanager->initHooks(array('admin'));
+
+// Load translation files required by the page
+
+$action = GETPOST('action', 'alpha') ?GETPOST('action', 'alpha') : 'view';
+$confirm = GETPOST('confirm', 'alpha');
+$id = GETPOST('id', 'int');
+$rowid = GETPOST('rowid', 'alpha');
+$entity = GETPOST('entity', 'int');
+$code = GETPOST('code', 'alpha');
+
+$acts =array(); $actl =array();
+$acts[0] = "activate";
+$acts[1] = "disable";
+$actl[0] = img_picto($langs->trans("Disabled"), 'switch_off');
+$actl[1] = img_picto($langs->trans("Activated"), 'switch_on');
+
+$listoffset = GETPOST('listoffset');
+$listlimit = GETPOST('listlimit') > 0 ?GETPOST('listlimit') : 1000; // To avoid too long dictionaries
+$active = 1;
+
+$sortfield = GETPOST("sortfield", 'alpha');
+$sortorder = GETPOST("sortorder", 'alpha');
+$page = GETPOST("page", 'int');
+if (empty($page) || $page == -1) { $page = 0; }     // If $page is not defined, or '' or -1
+$offset = $listlimit * $page;
+$pageprev = $page - 1;
+$pagenext = $page + 1;
+
+
+// This page is a generic page to edit dictionaries
+// Put here declaration of dictionaries properties
+
+// Sort order to show dictionary (0 is space). All other dictionaries (added by modules) will be at end of this.
+$taborder = array(9, 0, 4, 3, 2, 0, 1, 8, 19, 16, 27, 38, 0, 5, 11, 0, 32, 33, 34, 0, 6, 0, 29, 0, 7, 24, 28, 17, 35, 36, 0, 10, 23, 12, 13, 0, 14, 0, 22, 20, 18, 21, 0, 15, 30, 0, 37, 0, 25, 0);
+
+// Name of SQL tables of dictionaries
+$tabname = array();
+$tabname[1] = MAIN_DB_PREFIX."c_forme_juridique";
+
+// Dictionary labels
+$tablib = array();
+$tablib[1] = "DictionaryCompanyJuridicalType";
+
+// Requests to extract data
+$tabsql = array();
+$tabsql[1] = "SELECT f.rowid as rowid, f.code, f.libelle, c.code as country_code, c.label as country, f.active FROM ".MAIN_DB_PREFIX."c_forme_juridique as f, ".MAIN_DB_PREFIX."c_country as c WHERE f.fk_pays=c.rowid";
+
+// Criteria to sort dictionaries
+$tabsqlsort = array();
+$tabsqlsort[1] = "country ASC, code ASC";
+
+// Field names in select result for dictionary display
+$tabfield = array();
+$tabfield[1] = "code,libelle,country";
+
+// Edit field names for editing a record
+$tabfieldvalue = array();
+$tabfieldvalue[1] = "code,libelle,country";
+
+// Field names in the table for inserting a record
+$tabfieldinsert = array();
+$tabfieldinsert[1] = "code,libelle,fk_pays";
+
+// Rowid name of field depending if field is autoincrement on or off..
+// Use "" if id field is "rowid" and has autoincrement on
+// Use "nameoffield" if id field is not "rowid" or has not autoincrement on
+$tabrowid = array();
+$tabrowid[1] = "";
+
+// Condition to show dictionary in setup page
+$tabcond = array();
+$tabcond[1] = (!empty($conf->societe->enabled));
+
+// List of help for fields
+$tabhelp = array();
+$tabhelp[1]  = array('code'=>$langs->trans("EnterAnyCode"));
+// List of check for fields (NOT USED YET)
+$tabfieldcheck = array();
+$tabfieldcheck[1]  = array();
+
+// Defaut sortorder
+if (empty($sortfield))
+{
+	$tmp1 = explode(',', $tabsqlsort[$id]);
+	$tmp2 = explode(' ', $tmp1[0]);
+	$sortfield = preg_replace('/^.*\./', '', $tmp2[0]);
+}
+
+/*
+ * Actions
+ */
+
+_handleActions($db);
+exit;
+
+/**
+ *	Show fields in insert/edit mode
+ *
+ * 	@param		array		$fieldlist		Array of fields
+ * 	@param		Object		$obj			If we show a particular record, obj is filled with record fields
+ *  @param		string		$tabname		Name of SQL table
+ *  @param		string		$context		'add'=Output field for the "add form", 'edit'=Output field for the "edit form", 'hide'=Output field for the "add form" but we dont want it to be rendered
+ *	@return		string						'' or value of entity into table
+ */
+function fieldList($fieldlist, $obj = '', $tabname = '', $context = '')
+{
+	global $conf, $langs, $db, $mysoc;
+	global $form;
+	global $region_id;
+	global $elementList, $sourceList, $localtax_typeList;
+
+	$formadmin = new FormAdmin($db);
+	$formcompany = new FormCompany($db);
+	$formaccounting = new FormAccounting($db);
+
+	$withentity = '';
+
+	foreach ($fieldlist as $field => $value)
+	{
+		if ($fieldlist[$field] == 'entity') {
+			$withentity = $obj->{$fieldlist[$field]};
+			continue;
+		}
+
+		if (in_array($fieldlist[$field], array('code', 'libelle', 'type')) && $tabname == MAIN_DB_PREFIX."c_actioncomm" && in_array($obj->type, array('system', 'systemauto')))
+		{
+			$hidden = (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'');
+			print '<td>';
+			print '<input type="hidden" name="'.$fieldlist[$field].'" value="'.$hidden.'">';
+			print $langs->trans($hidden);
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'country')
+		{
+			if (in_array('region_id', $fieldlist))
+			{
+				print '<td>';
+				print '</td>';
+				continue;
+			}	// For state page, we do not show the country input (we link to region, not country)
+			print '<td>';
+			$fieldname = 'country';
+			print $form->select_country((!empty($obj->country_code) ? $obj->country_code : (!empty($obj->country) ? $obj->country : '')), $fieldname, '', 28, 'maxwidth150 maxwidthonsmartphone');
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'country_id')
+		{
+			if (!in_array('country', $fieldlist))	// If there is already a field country, we don't show country_id (avoid duplicate)
+			{
+				$country_id = (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]} : 0);
+				print '<td class="tdoverflowmax100">';
+				print '<input type="hidden" name="'.$fieldlist[$field].'" value="'.$country_id.'">';
+				print '</td>';
+			}
+		}
+		elseif ($fieldlist[$field] == 'region')
+		{
+			print '<td>';
+			$formcompany->select_region($region_id, 'region');
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'region_id')
+		{
+			$region_id = (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:0);
+			print '<td>';
+			print '<input type="hidden" name="'.$fieldlist[$field].'" value="'.$region_id.'">';
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'lang')
+		{
+			print '<td>';
+			print $formadmin->select_language($conf->global->MAIN_LANG_DEFAULT, 'lang');
+			print '</td>';
+		}
+		// The type of the element (for contact types)
+		elseif ($fieldlist[$field] == 'element')
+		{
+			print '<td>';
+			print $form->selectarray('element', $elementList, (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''));
+			print '</td>';
+		}
+		// The source of the element (for contact types)
+		elseif ($fieldlist[$field] == 'source')
+		{
+			print '<td>';
+			print $form->selectarray('source', $sourceList, (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''));
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'private')
+		{
+			print '<td>';
+			print $form->selectyesno("private", (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''));
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'type' && $tabname == MAIN_DB_PREFIX."c_actioncomm")
+		{
+			$type = (!empty($obj->type) ? $obj->type : 'user'); // Check if type is different of 'user' (external module)
+			print '<td>';
+			print $type.'<input type="hidden" name="type" value="'.$type.'">';
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'type' && $tabname == MAIN_DB_PREFIX.'c_paiement')
+		{
+			print '<td>';
+			$select_list = array(0=>$langs->trans('PaymentTypeCustomer'), 1=>$langs->trans('PaymentTypeSupplier'), 2=>$langs->trans('PaymentTypeBoth'));
+			print $form->selectarray($fieldlist[$field], $select_list, (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'2'));
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'recuperableonly' || $fieldlist[$field] == 'type_cdr' || $fieldlist[$field] == 'deductible' || $fieldlist[$field] == 'category_type') {
+			if ($fieldlist[$field] == 'type_cdr') print '<td class="center">';
+			else print '<td>';
+			if ($fieldlist[$field] == 'type_cdr') {
+				print $form->selectarray($fieldlist[$field], array(0=>$langs->trans('None'), 1=>$langs->trans('AtEndOfMonth'), 2=>$langs->trans('CurrentNext')), (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''));
+			} else {
+				print $form->selectyesno($fieldlist[$field], (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''), 1);
+			}
+			print '</td>';
+		}
+		elseif (in_array($fieldlist[$field], array('nbjour', 'decalage', 'taux', 'localtax1', 'localtax2'))) {
+			$class = "left";
+			if (in_array($fieldlist[$field], array('taux', 'localtax1', 'localtax2'))) $class = "center"; // Fields aligned on right
+			print '<td class="'.$class.'">';
+			print '<input type="text" class="flat" value="'.(isset($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]} : '').'" size="3" name="'.$fieldlist[$field].'">';
+			print '</td>';
+		}
+		elseif (in_array($fieldlist[$field], array('libelle_facture'))) {
+			print '<td>';
+			$transfound = 0;
+			$transkey = '';
+			// Special case for labels
+			if ($tabname == MAIN_DB_PREFIX.'c_payment_term')
+			{
+				$langs->load("bills");
+				$transkey = "PaymentCondition".strtoupper($obj->code);
+				if ($langs->trans($transkey) != $transkey)
+				{
+					$transfound = 1;
+					print $form->textwithpicto($langs->trans($transkey), $langs->trans("GoIntoTranslationMenuToChangeThis"));
+				}
+			}
+			if (!$transfound)
+			{
+				print '<textarea cols="30" rows="'.ROWS_2.'" class="flat" name="'.$fieldlist[$field].'">'.(!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'').'</textarea>';
+			}
+			else {
+				print '<input type="hidden" name="'.$fieldlist[$field].'" value="'.$transkey.'">';
+			}
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'price' || preg_match('/^amount/i', $fieldlist[$field])) {
+			print '<td><input type="text" class="flat minwidth75" value="'.price((!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'')).'" name="'.$fieldlist[$field].'"></td>';
+		}
+		elseif ($fieldlist[$field] == 'code' && isset($obj->{$fieldlist[$field]})) {
+			print '<td><input type="text" class="flat minwidth75 maxwidth100" value="'.(!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'').'" name="'.$fieldlist[$field].'"></td>';
+		}
+		elseif ($fieldlist[$field] == 'unit') {
+			print '<td>';
+			$units = array(
+				'mm' => $langs->trans('SizeUnitmm'),
+				'cm' => $langs->trans('SizeUnitcm'),
+				'point' => $langs->trans('SizeUnitpoint'),
+				'inch' => $langs->trans('SizeUnitinch')
+			);
+			print $form->selectarray('unit', $units, (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''), 0, 0, 0);
+			print '</td>';
+		}
+		// Le type de taxe locale
+		elseif ($fieldlist[$field] == 'localtax1_type' || $fieldlist[$field] == 'localtax2_type')
+		{
+			print '<td class="center">';
+			print $form->selectarray($fieldlist[$field], $localtax_typeList, (!empty($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:''));
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'accountancy_code' || $fieldlist[$field] == 'accountancy_code_sell' || $fieldlist[$field] == 'accountancy_code_buy')
+		{
+			print '<td>';
+			if (!empty($conf->accounting->enabled))
+			{
+				$fieldname = $fieldlist[$field];
+				$accountancy_account = (!empty($obj->$fieldname) ? $obj->$fieldname : 0);
+				print $formaccounting->select_account($accountancy_account, '.'.$fieldlist[$field], 1, '', 1, 1, 'maxwidth200 maxwidthonsmartphone');
+			}
+			else
+			{
+				$fieldname = $fieldlist[$field];
+				print '<input type="text" size="10" class="flat" value="'.(isset($obj->$fieldname) ? $obj->$fieldname : '').'" name="'.$fieldlist[$field].'">';
+			}
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'fk_tva')
+		{
+			print '<td>';
+			print $form->load_tva('fk_tva', $obj->taux, $mysoc, new Societe($db), 0, 0, '', false, -1);
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'fk_c_exp_tax_cat')
+		{
+			print '<td>';
+			print $form->selectExpenseCategories($obj->fk_c_exp_tax_cat);
+			print '</td>';
+		}
+		elseif ($fieldlist[$field] == 'fk_range')
+		{
+			print '<td>';
+			print $form->selectExpenseRanges($obj->fk_range);
+			print '</td>';
+		}
+		else
+		{
+			$fieldValue = isset($obj->{$fieldlist[$field]}) ? $obj->{$fieldlist[$field]}:'';
+
+			if ($fieldlist[$field] == 'sortorder')
+			{
+				$fieldlist[$field] = 'position';
+			}
+
+			$classtd = ''; $class = '';
+			if ($fieldlist[$field] == 'code') $class = 'maxwidth100';
+			if (in_array($fieldlist[$field], array('dayrule', 'day', 'month', 'year', 'pos', 'use_default', 'affect', 'delay', 'position', 'sortorder', 'sens', 'category_type'))) $class = 'maxwidth50';
+			if (in_array($fieldlist[$field], array('libelle', 'label', 'tracking'))) $class = 'quatrevingtpercent';
+			print '<td class="'.$classtd.'">';
+			$transfound = 0;
+			$transkey = '';
+			if (in_array($fieldlist[$field], array('label', 'libelle')))		// For label
+			{
+				// Special case for labels
+				if ($tabname == MAIN_DB_PREFIX.'c_civility') {
+					$transkey = "Civility".strtoupper($obj->code);
+				}
+				if ($tabname == MAIN_DB_PREFIX.'c_payment_term') {
+					$langs->load("bills");
+					$transkey = "PaymentConditionShort".strtoupper($obj->code);
+				}
+				if ($transkey && $langs->trans($transkey) != $transkey)
+				{
+					$transfound = 1;
+					print $form->textwithpicto($langs->trans($transkey), $langs->trans("GoIntoTranslationMenuToChangeThis"));
+				}
+			}
+			if (!$transfound)
+			{
+				print '<input type="text" class="flat'.($class ? ' '.$class : '').'" value="'.dol_escape_htmltag($fieldValue).'" name="'.$fieldlist[$field].'">';
+			}
+			else {
+				print '<input type="hidden" name="'.$fieldlist[$field].'" value="'.$transkey.'">';
+			}
+			print '</td>';
+		}
+	}
+
+	return $withentity;
+}
+
+function _handleActions($db) {
+	$action = GETPOST('action', 'alpha');
+	if (empty($action)) $action = 'view';
+
+	$callbackName = '_action' . _camel($action);
+	if (!function_exists($callbackName)) {
+		setEventMessages('UnknownAction', array(), 'errors');
+		header('Location: ' . $_SERVER['PHP_SELF']);
+		exit;
+	}
+	call_user_func($callbackName, $db);
+}
+
+function _actionAdd($db) {
+
+}
+
+function _actionModify($db) {
+	$id = GETPOST('id', 'int');
+	_showDictionary($db, 'modify', $id);
+}
+
+function _actionView($db) {
+	_showDictionary($db, 'view', intval(GETPOST('id', 'int'))));
+}
+
+function _actionDelete($db) {
+	global $langs;
+	global $delayedhtmlcontent;
+	$form = new Form($db);
+	$delayedhtmlcontent .= $form->formconfirm(
+		$_SERVER["PHP_SELF"].'?'.($page ? 'page='.$page.'&' : '').$paramwithsearch,
+		$langs->trans('DeleteLine'),
+		$langs->trans('ConfirmDeleteLine'),
+		'confirm_delete',
+		'',
+		0,
+		1
+	);
+	_showDictionary($db, 'view', intval(GETPOST('id', 'int')));
+}
+
+function _actionConfirmDelete($db) {
+	$id = GETPOST('id', 'int');
+	$sql = 'DELETE FROM ' . MAIN_DB_PREFIX . 'multicurrency_rate'
+		   .' WHERE rowid = ' . intval($id);
+
+	_showDictionary($db, 'view');
+}
+
+function _showDictionary($db, $mode='view', $id=NULL) {
+	global $langs;
+	$form = new Form($db);
+	$formadmin = new FormAdmin($db);
+	$title = $langs->trans('CurrencyRateSetup');
+	$limit = 123;
+
+	$TVisibleColumn = array(
+		'rate.date_sync' => array('Date'),
+		'rate.rate' => array('Number'),
+		'currency.code' => array('CurrencyCode'),
+		'rate.entity' => array(),
+	);
+	foreach ($TVisibleColumn as $colSelect => &$colParam) {
+		$colParam['name'] = _columnAlias($colSelect);
+	}
+	unset($colParam);
+
+	$sql = 'SELECT rate.rowid, ' . join(', ', array_keys($TVisibleColumn)) . ' FROM ' . MAIN_DB_PREFIX . 'multicurrency_rate rate'
+		   . ' LEFT JOIN ' . MAIN_DB_PREFIX . 'multicurrency currency ON rate.fk_multicurrency = currency.rowid'
+		   . ' WHERE 1 = 1'
+		   . ' LIMIT ' . intval($limit);
+	$resql = $db->query($sql);
+	if (!$resql) {
+		llxFooter();
+		return;
+	}
+	$num_rows = $db->num_rows($resql);
+
+	llxHeader();
+	echo load_fiche_titre($title, $linkback, $titlepicto);
+
+	echo '<table class="noborder centpercent">';
+	echo '<thead>';
+	echo '<tr>';
+
+	// titres
+	foreach ($TVisibleColumn as $colSelect => $colParam) {
+		echo '<th>';
+		echo $langs->trans('multicurrencyColumn' . _camel(ucfirst($colParam['name'])));
+		echo '</th>';
+	}
+	echo '<th></th>';
+	echo '</tr>';
+	echo '</thead>';
+	echo '<tbody>';
+	if (!$num_rows) {
+		echo '<tr>';
+		$colspan = count($TVisibleColumn);
+		$colspan += 1; // account for the action column
+		echo '<td colspan="' . $colspan . '">' . $langs->trans('NoResults') . '</td>';
+		echo '</tr>';
+	}
+	for ($i = 0; $i < $num_rows; $i++) {
+		$obj = $db->fetch_object($resql);
+		if (!$obj) { break; }
+		echo '<tr data-id="' . intval($obj->rowid) . '">';
+		foreach ($TVisibleColumn as $colSelect => $colParam) {
+			$rawValue = $obj->{$colParam['name']};
+
+			// default callback for how to display the raw value
+			$cellContentCallback = '_getCellDefault';
+
+			// possible override in column definition
+			if (isset($colParam['callback'])) {
+				$cbName = $colParam['callback'];
+				// mandatory function name prefix: '_getCell' (some day, the callback may come from untrusted input)
+				if (strpos($cbName, '_getCell') !== 0) $cbName = '_getCell' . $cbName;
+				if (function_exists($cbName)) { $cellContentCallback = $cbName; }
+			}
+
+			if ($mode === 'modify' && $obj->rowid === $id) {
+				$cellContent = call_user_func($cellContentCallback, $rawValue, 'modify', $colParam['name']);
+			} else {
+				$cellContent = call_user_func($cellContentCallback, $rawValue, 'view', $colParam['name']);
+			}
+			echo '<td>' . $cellContent . '</td>';
+		}
+
+		echo '<td>'
+			 . '<a href="?action=modify&id=' . intval($obj->rowid) . '">' . img_picto('edit', 'edit') . '</a>'
+			 . '<a href="?action=delete&id=' . intval($obj->rowid) . '">' . img_picto('delete', 'delete') . '</a>'
+			 . '</td>';
+		echo '</tr>';
+	}
+	echo '</tbody>';
+	echo '</table>';
+
+	// End of page
+	llxFooter();
+	$db->close();
+}
+
+/**
+ * @param $rawValue
+ * @param string $mode
+ * @param string $inputName
+ * @return string
+ */
+function _getcellDefault($rawValue, $mode='view', $inputName='') {
+	if ($mode === 'view') {
+		return dol_escape_htmltag($rawValue);
+	} elseif ($mode === 'modify') {
+		return '<input value="'
+			   . htmlspecialchars($rawValue, ENT_QUOTES)
+			   . '" name="' . $inputName
+			   . '" />';
+	}
+}
+
+/**
+ * Returns the name of the column in the object returned by DoliDB::fetch_object
+ *
+ * Example:
+ *   $colSelect = 'abcd'               => 'abcd' // no table name, no alias
+ *                'table.xyz AS abcd'  => 'abcd' // with table name
+ *                'table.abcd'         => 'abcd' // with table name and alias
+ *                'xyz AS abcd'        => 'xyz AS abcd' // not handled: alias without table name
+ * @param string $colSelect
+ * @return string
+ */
+function _columnAlias($colSelect) {
+	// the regexp replacement does this:
+	//     'table.abcd AS efgh' => 'efgh'
+	// regexp explanation:
+	//     '.*\.`?'     => not captured:  anything, then a dot, then an optional backtick;
+	//     '([^ `]+)`?' => capture 1:     anything that doesn't have a space or a backtick (then an optional, uncaptured backtick)
+	//     '(?:.....)?' => non-capturing: makes whatever is inside the parentheses optional
+	//     '\s+as\s+`?' => not captured:  whitespace, then 'AS', then whitespace, then an optional backtick
+	//     '([^ `]+)'   => capture 2:     anything that doesn't have a space or a backtick
+	return preg_replace_callback(
+		'/^.*\.`?([^ `]+)`?(?:\s+as\s+`?([^ `]+)`?)?/i',
+		function ($m) { return isset($m[2]) ? $m[2] : $m[1]; },
+		$colSelect
+	);
+}
+
+/**
+ * Returns $str in camel case ("snake_case_versus_camel_case" => 'snakeCaseVersusCamelCase')
+ * @param $str
+ * @return string|string[]|null
+ */
+function _camel($str) {
+	return preg_replace_callback('/_(.)?/', function($m) { return ucfirst($m[1]); }, $str);
+}

--- a/htdocs/multicurrency/multicurrency_rates.php
+++ b/htdocs/multicurrency/multicurrency_rates.php
@@ -577,18 +577,6 @@ function _actionAdd($db, $TVisibleColumn) {
 		if ($rescreate <= 0) {
 			setEventMessages($langs->trans('MulticurrencyErrorCouldNotCreateRate', $rate, $code), array(), 'errors');
 		}
-//		$sql = 'INSERT INTO ' . MAIN_DB_PREFIX . 'multicurrency_rate (`date_sync`, `rate`, `fk_multicurrency`, `entity`)'
-//			   . ' VALUES ('
-//			   . ' "' . $db->escape($dateSync) . '"'
-//			   . ', "' . $db->escape($rate) . '"'
-//			   . ', ' . intval($multiCurrency->id)
-////			   . ', (SELECT rowid FROM llx_multicurrency WHERE code = "'. $db->escape($code) . '" AND entity IN ('. getEntity('multicurrency') .') LIMIT 1)'
-//			   . ',"' . $db->escape($entity) . '"'
-//			   .')';
-//		$resql = $db->query($sql);
-//		if (!$resql) {
-//			setEventMessages($langs->trans('MulticurrencyErrorCouldNotCreateRate', $rate, $code), array(), 'errors');
-//		}
 	}
 	_mainView($db, $TVisibleColumn, 'view');
 }
@@ -611,15 +599,6 @@ function _actionUpdate($db, $TVisibleColumn) {
 	$id = intval(GETPOST('id', 'int'));
 	$dateSync = GETPOST('date_sync', 'alpha');
 	$rate = GETPOST('rate', 'int');
-//	$date = date_parse($dateSync);
-//	$date = dol_mktime(
-//		$date['hour'],
-//		$date['minute'],
-//		$date['second'],
-//		$date['month'],
-//		$date['day'],
-//		$date['year']
-//	);
 	$mcRate = new CurrencyRate($db);
 	$resfetch = $mcRate->fetch($id);
 	if ($resfetch <= 0) {
@@ -628,12 +607,6 @@ function _actionUpdate($db, $TVisibleColumn) {
 		$mcRate->date_sync = $dateSync;
 		$mcRate->rate = $rate;
 		$resupdate = $mcRate->update();
-//		$sql = /** @lang SQL */
-//			'UPDATE ' . MAIN_DB_PREFIX . 'multicurrency_rate SET'
-//			. '   date_sync = "' . $db->idate($date) . '",'
-//			. '   rate = "' . price2num($rate) . '"'
-//			. ' WHERE rowid = ' . $id;
-//		$resql = $db->query($sql);
 		if ($resupdate <= 0) {
 			setEventMessages($langs->trans($db->lasterror), array(), 'errors');
 		} else {
@@ -690,9 +663,6 @@ function _actionConfirmDelete($db, $TVisibleColumn) {
 		if ($resfetch <= 0) {
 			setEventMessages($langs->trans('MulticurrencyErrorCouldNotFetchRate', $id), array(), 'errors');
 		} else {
-//			$sql = 'DELETE FROM ' . MAIN_DB_PREFIX . 'multicurrency_rate'
-//				   . ' WHERE rowid = ' . $id;
-//			$resql = $db->query($sql);
 			$resdelete = $mcRate->delete();
 			if ($resdelete <= 0) {
 				setEventMessages($db->lasterror, array(), 'errors');
@@ -801,13 +771,3 @@ function _formHiddenInputs($TVisibleColumn) {
 	));
 	return $ret;
 }
-
-///**
-// * Avoids generating a different token for every <form> on the page;
-// *
-// * @return string  new session token on first call; same token on subsequent calls
-// */
-//function newToken() {
-//	static $token = null; if ($token === null) $token = newToken();
-//	return $token;
-//}


### PR DESCRIPTION
# [NOTE POUR ATM] : ne pas valider avant [la PR cœur](https://github.com/Dolibarr/dolibarr/pull/14820)
Le merge de la PR cœur a été annulé, du coup, ne pas merger (il faut refaire la page).

# New multi-currency exchange rate editor
## Context
Currently multicurrency logs past exchange rates when you "update" the exchange rate of a currency, but it doesn't enable you to correct past exchange rates or to date an exchange rate when you add it (the date is automatically set to the current time).

## This PR
This PR introduces a new page that enables you to view, edit or add exchange rates in a way somewhat similar to Dolibarr dictionaries. The page is accessible via the main menu "Tools".

![multicurrency-rate-edit](https://user-images.githubusercontent.com/50440633/94025579-f2f25900-fdb8-11ea-810d-edf376ef2ee0.png)

