### PR TITLE
FIX: when a proposal gets signed as part of a mass action, ensure the third party's status is updated to 'customer'

### DIFF
--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -3538,8 +3538,7 @@ class Propal extends CommonObject
 				$error++;
 			}
 		} else if ($nextStatus == $this::STATUS_SIGNED && $this->statut == $this::STATUS_VALIDATED) {
-			$this->statut = $this::STATUS_SIGNED;
-			if (!$this->update($user)){
+			if ($this->cloture($user, $this::STATUS_SIGNED) <= 0) {
 				dol_print_error($this->db);
 				$error++;
 			}


### PR DESCRIPTION
# FIX
On the proposal list, the mass action "sign" should call `Propal->cloture()` to ensure the third party's status is updated in the same way as on the card (e.g. its "prospect" status should be updated to "customer").

Note: a core PR into develop is also going to be opened soon.