### PR TITLE
FIX 10.0_maintlog - formConfirm should be treated as an addreplace ho…

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -160,6 +160,7 @@ class HookManager
 				'doActions',
 				'doMassActions',
 				'formatEvent',
+				'formConfirm',
 				'formCreateThirdpartyOptions',
 				'formObjectOptions',
 				'formattachOptions',


### PR DESCRIPTION
# FIX

cf. https://github.com/Dolibarr/dolibarr/pull/15202

Currently, if your module returns 1 in its `formConfirm()` and then another module's returns 0, `executeHooks()` will return 0.

With this PR, it will return 1.