### PR TITLE
Fix/10.0 maintlog remove action parameter from redirect url when moving lines

### DIFF
--- a/htdocs/core/class/hookmanager.class.php
+++ b/htdocs/core/class/hookmanager.class.php
@@ -160,6 +160,7 @@ class HookManager
 				'doActions',
 				'doMassActions',
 				'formatEvent',
+				'formConfirm',
 				'formCreateThirdpartyOptions',
 				'formObjectOptions',
 				'formattachOptions',

--- a/htdocs/core/tpl/ajaxrow.tpl.php
+++ b/htdocs/core/tpl/ajaxrow.tpl.php
@@ -80,7 +80,12 @@ $(document).ready(function(){
 						console.log("tableDND end of ajax call");
 						if (reloadpage == 1) {
 							//console.log('<?php echo $urltorefreshaftermove.' - '.$_SERVER['PHP_SELF'].' - '.dol_escape_js($_SERVER['QUERY_STRING']); ?>');
-							location.href = '<?php echo dol_escape_js(empty($urltorefreshaftermove) ? ($_SERVER['PHP_SELF'].'?'.dol_escape_js($_SERVER['QUERY_STRING'])) : $urltorefreshaftermove); ?>';
+							<?php
+							$redirectURL = empty($urltorefreshaftermove) ? ($_SERVER['PHP_SELF'].'?'.dol_escape_js($_SERVER['QUERY_STRING'])) : $urltorefreshaftermove;
+							// remove action parameter from URL
+							$redirectURL = preg_replace('/[&?]action=[^&]*/', '', $redirectURL);
+							?>
+							location.href = '<?php echo dol_escape_js($redirectURL); ?>';
 						} else {
 							$("#<?php echo $tagidfortablednd; ?> .drag").each(
 									function( intIndex ) {


### PR DESCRIPTION
# FIX
cf. https://github.com/Dolibarr/dolibarr/pull/15213

When you drag & drop a line on a proposal/invoice/order card, there is a redirect to the current URL, but if the current URL contains an `action` parameter, the action is performed again. This PR removes the action parameter.

Note: includes [this PR](https://github.com/ATM-Consulting/dolibarr/pull/128)