### PR TITLE
FIX : Dicsount TVA on propal when clone if customer not subject to TVA

### DIFF
--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -195,6 +195,25 @@ if (empty($reshook))
 
 				$result = $object->createFromClone($user, $socid);
 				if ($result > 0) {
+					$soc = new  Societe($db);
+					$obj = $soc->fetch(GETPOST('socid'));
+					if ($obj == 1 && $soc->tva_assuj != 1) {
+						$propal = new Propal($db);
+						$obj = $propal->fetch($result);
+						if ($obj) {
+							foreach ($propal->lines as $line) {
+								$line->tva_tx = 0;
+								$line->total_ttc = $line->total_ttc - $line->total_tva;
+								$line->total_tva = 0;
+								$line->multicurrency_total_ttc = $line->multicurrency_total_ttc - $line->multicurrency_total_tva;
+								$line->multicurrency_total_tva = 0;
+								$line->update($user);
+							}
+							$propal->total_ttc = $propal->total_ttc - $propal->total_tva;
+							$propal->total_tva = 0;
+							$propal->update($user);
+						}
+					}
 					header("Location: ".$_SERVER['PHP_SELF'].'?id='.$result);
 					exit();
 				} else {


### PR DESCRIPTION
## FIX : Lors du clonnage de propals, remise de la TVA à 0 si le client selectionné n'est pas assujetti à la TVA

**Lors du clonnage de propal, si le client selectionné n'est pas assujetti à la TVA** : 
- Remise de la TVA sur toutes les lignes de la propal à 0
- Remise de la TVA à 0  sur tous les champs affecté par la TVA
