### PR TITLE
FIX clonage ticket : prise en compte du feedback de PR

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -416,9 +416,11 @@ class FormTicket
 		$reshook = $hookmanager->executeHooks('formObjectOptions', $parameters, $ticketstat, $this->action); // Note that $action and $object may have been modified by hook
 		if (empty($reshook))
 		{
-            $ticketstat->array_options = array_merge($ticketstat->array_options,$this->array_options);
-
-            print $ticketstat->showOptionals($extrafields, 'create');
+			$clone_id = GETPOST('clone_id', 'int');
+			if (!empty($clone_id)) {
+				$ticketstat->fetch_optionals($clone_id);
+			}
+			print $ticketstat->showOptionals($extrafields, 'create');
 		}
 
 		print '</table>';

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -644,7 +644,7 @@ if ($action == 'create' || $action == 'presend')
 	if (empty($defaultref)) {
 		$defaultref = '';
 	}
-    if ($action == 'create' && isset($clone_id)) {
+    if ($action == 'create' && !empty($clone_id)) {
         $object->fetch($clone_id);
 
         $formticket->severity_code = $object->severity_code;
@@ -656,8 +656,6 @@ if ($action == 'create' || $action == 'presend')
 
         $formticket->withfromcontactid = $contact[0]['id'];
         $formticket->withfromcontactrole = $contact[0]['fk_c_type_contact'];
-
-        $formticket->array_options = $object->array_options;
 
         ?>
         <script type="text/javascript" language="javascript">


### PR DESCRIPTION
# FIX
Cette PR est une réédition de [celle-ci](https://github.com/ATM-Consulting/dolibarr/pull/132) mais avec un ordre de commit différent car on avait un souci de diff.

Le but est d'amender [cette PR](https://github.com/ATM-Consulting/dolibarr/pull/127) (mergée) pour prendre en compte le retour sur `array_options`.

La [PR initiale](https://github.com/ATM-Consulting/dolibarr/pull/99) permet le clonage de tickets.

Note : il y avait beaucoup d'autres commentaires de PR sur `index.php`, qui ne sont pas pris en compte ici car il a été demandé de ne pas toucher à `index.php` à part les liens "Ticketsup" à convertir en liens "Ticket".