### PR TITLE
10.0 maintlog new t2433 alert command list

### DIFF
--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -1011,6 +1011,8 @@ if ($resql)
 				}
 			}
 
+			/*———FIN DEV SPECIFIQUE MAINTLOG———*/
+
 			// Warning late icon and note
 			print '<td class="nobordernopadding nowrap">';
 			if ($generic_commande->hasDelay()) {
@@ -1027,6 +1029,7 @@ if ($resql)
 			if($alert_qty && $alert_price){
 				print '<span class="fas fa-parachute-box" style=" color: #800000;"></span>';
 			}
+			/*———FIN DEV SPECIFIQUE MAINTLOG———*/
 
 			print '</td>';
 

--- a/htdocs/commande/list.php
+++ b/htdocs/commande/list.php
@@ -1024,7 +1024,7 @@ if ($resql)
 			}
 			/*DEV SPECIFIQUE MAINTLOG*/
 			//T2433 - Affichage picto
-			if($alert_qty || $alert_price){
+			if($alert_qty && $alert_price){
 				print '<span class="fas fa-parachute-box" style=" color: #800000;"></span>';
 			}
 


### PR DESCRIPTION
# New Alerte sur liste de commandes
 
Une alerte s'affiche à côté de la ref commande quand les deux conditions ci-après sont fausses : 

   - la somme des prix d'achat des produits de la commande client ne correspond pas au total des prix HT des commandes fournisseurs 

   - la quantité totale des lignes de produits / services (hors produit / service possédant un attribut complémentaire case à cocher "
Exclure de l'alerte commande client / fournisseur") des commandes clients ne correspond pas à la quantité totale des lignes de produits / services des commandes fournisseur (hors produit / service possédant un attribut complémentaire case à cocher "Exclure l'alerte commande client / fournisseur")