### PR TITLE
NEW Hook on thirdparty customer's tab__AND__Fix email bug on v12

### DIFF
--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -1238,6 +1238,12 @@ if ($object->id > 0)
 		}
 	}
 
+	// Allow external modules to add their own shortlist of recent objects
+	$parameters = array();
+	$reshook = $hookmanager->executeHooks('addMoreRecentObjects', $parameters, $object, $action);
+	if ($reshook < 0) setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	else print $hookmanager->resPrint;
+
 	print '</div></div></div>';
 	print '<div style="clear:both"></div>';
 

--- a/htdocs/core/tpl/card_presend.tpl.php
+++ b/htdocs/core/tpl/card_presend.tpl.php
@@ -209,7 +209,7 @@ if ($action == 'presend')
 	}
 
 	$formmail->withto = $liste;
-	$formmail->withtofree = (GETPOSTISSET('sendto') ? (GETPOST('sendto') ? GETPOST('sendto') : '1') : '1');
+	$formmail->withtofree = (GETPOSTISSET('sendto') ? (GETPOST('sendto', 'alpha') ? GETPOST('sendto', 'alpha') : '1') : '1');
 	$formmail->withtocc = $liste;
 	$formmail->withtoccc = $conf->global->MAIN_EMAIL_USECCC;
 	$formmail->withtopic = $topicmail;


### PR DESCRIPTION
# New 
Add Hook on thirdparty customer's tab to allow external modules to add shortlist of recent objects

# Fix
Fix display bug on email presend
In the case of an email presend, the email addresses of the recipients are in the "< aaaa@aaaa.fr >" format.
The default 'alphanohtml' parameter of the GETPOST deletes the chevrons as well as the contents inside the chevrons.