### PR TITLE
FIX : Extrafields liés

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6568,8 +6568,27 @@ abstract class CommonObject
 								var parent = $(this).find("option[parent]:first").attr("parent");
 								var infos = parent.split(":");
 								var parent_list = infos[0];
+								//Hide daughters lists
+								if ($("#"+child_list).val() == 0 && $("#"+parent_list).val() == 0){
+								    $("#"+child_list).hide();
+								//Show mother lists
+								} else if ($("#"+parent_list).val() != 0){
+								    $("#"+parent_list).show();
+								}
+								//show the child list if the parent list value is selected
+								$("select[name=\""+parent_list+"\"]").click(function() {
+								    if ($(this).val() != 0){
+								        $("#"+child_list).show()
+									}
+								});
 								$("select[name=\""+parent_list+"\"]").change(function() {
 									showOptions(child_list, parent_list);
+									//Select the value 0 on child list on change on the parent list
+									$("#"+child_list).val(0).trigger("change");
+									//Hide child lists if the parent value is set to 0
+									if ($(this).val() == 0){
+								   		$("#"+child_list).hide();
+									}
 								});
 					    	});
 						}


### PR DESCRIPTION
## FIX : Champs complémentaires dépendant les uns des autres 

**Le système de champ complémentaires liés ne fonctionne pas correctement. En effet, il ne devrait pas être possible de sélectionner la valeur d'un champ fils avant d'avoir saisie celle de son champ père :** 

- Les champs enfants n'apparaissent pas tant que la valeur de leurs champs père n'ont pas été saisie 
- Les champs enfants sont vidés lorsque la valeur de leur champs père est changée
- Les champs enfants disparaissent lorsque la valeur de leurs champs père est vidée manuellement 

De cette manière, il n'est plus possible de saisir dans un champ fils avant d'avoir saisi celle du père 