### PR TITLE
FIX : Extrafields liés, valeurs alphanumériques

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6555,7 +6555,15 @@ abstract class CommonObject
 				    	{
 				    		var val = $("select[name=\""+parent_list+"\"]").val();
 				    		var parentVal = parent_list + ":" + val;
-							if(val > 0) {
+				    		console.log(typeof val)
+				    		if(typeof val == "string"){
+				    		    if(val != "") {
+					    			$("select[name=\""+child_list+"\"] option[parent]").hide();
+					    			$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
+								} else {
+									$("select[name=\""+child_list+"\"] option").show();
+								}
+				    		} else if(val > 0) {
 					    		$("select[name=\""+child_list+"\"] option[parent]").hide();
 					    		$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
 							} else {


### PR DESCRIPTION
## FIX : Extrafields liés, valeurs alphanumériques

**Il n'était pas possible pour un utilisateur de faire fonctionner le système des extrafields liés avec des valeurs (de liste) de type String :**
- Ajout d'une partie sur condition afin que soit accepté les valeurs alphanumérique pour les éléments/options des listes 