### PR TITLE
FIX : Système de champs complémentaire liés : listes et multiselect 

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6560,21 +6560,25 @@ abstract class CommonObject
 						*/
 				    	function showOptions(child_list, parent_list)
 				    	{
-				    		var val = $("select[name=\""+parent_list+"\"]").val();
-				    		var parentVal = parent_list + ":" + val;
+				    	    let child = $("select#" + child_list);
+				    	    let parent = $("select#" + parent_list);
+				    		let val = parent.val();
+				    		let parentVal = parent_list + ":" + val;
+							let childOptionsWithAParent = child.find("option[parent]");
+							let childOptionsWithSelectedParent = child.find("option[parent=\"" + parentVal + "\"]");
 				    		if(typeof val == "string"){
 				    		    if(val != "") {
-					    			$("select[name=\""+child_list+"\"] option[parent]").hide();
-					    			$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
+					    			childOptionsWithAParent.hide();
+					    			childOptionsWithSelectedParent.show();
 								} else {
-									$("select[name=\""+child_list+"\"] option").show();
+									child.find("option").show();
 								}
 				    		} else if(val > 0) {
-					    		$("select[name=\""+child_list+"\"] option[parent]").hide();
-					    		$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
-							} else {
-								$("select[name=\""+child_list+"\"] option").show();
-							}
+					    		childOptionsWithAParent.hide();
+					    			childOptionsWithSelectedParent.show();
+								} else {
+									child.find("option").show();
+								}
 				    	}
 				    	/**
 				        * Make multiselect options visible or invisible depending on what option is selected in the parent select
@@ -6584,100 +6588,103 @@ abstract class CommonObject
 						*/
 				    	function showOptionsOnMultiselect(child_list, parent_list){
 
-				    	    var val = $("select[name=\""+parent_list+"\"]").val();
-				    		var parentVal = parent_list + ":" + val;
+				    	    let val = $("select[name=\""+parent_list+"\"]").val();
+				    		let parentVal = parent_list + ":" + val;
+				    		let child = $("select#" + child_list);
+//				    		console.log(parentVal)
+//				    		console.log(child_list);
 				    		if(typeof val == "string"){
-				    		    if(val != "") {
+				    		    if(val !== "") {
 				    		        if($("#"+child_list).hasClass("multiselect")){
-								     	var allOptionsWithParent = $("select[id=\""+child_list+"\"] option")
-								        var optionsToShow = $("select[id=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
-								        $("#"+child_list).select2();
-								        for (option of allOptionsWithParent){
-								            option.disabled = true;
-								        }
-								        for (option of optionsToShow){
-								            option.disabled = false;
-								        }
-								        $("span.select2-selection.select2-selection--multiple").click(function() {
-								        	var select2_liToHide = $(".select2-results__option[aria-disabled=true]")
-								        	for (li of select2_liToHide){
-								        	    $(li).css("display", "none")
-								        	}
-										});
+										let allOptionsWithParent = child.find("option");
+										console.log(multiSelectOptionsByParent)
+										let optionsByParent = multiSelectOptionsByParent[child_list];
+//										console.log(multiSelectOptionsByParent[child_list])
+//										console.log(optionsByParent[parentVal])
+										child.empty().select2({data: optionsByParent[parentVal]});
 					    			}
 		    		    		}
 				    		} else if(val > 0) {
 				    		    if($("#"+child_list).hasClass("multiselect")){
-								     	var allOptionsWithParent = $("select[id=\""+child_list+"\"] option")
-								        var optionsToShow = $("select[id=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
-								     	$("#"+child_list).select2();
-								        for (option of allOptionsWithParent){
-								            option.disabled = true;
-								        }
-								        for (option of optionsToShow){
-								            option.disabled = false;
-								        }
-								        $("span.select2-selection.select2-selection--multiple").click(function() {
-								            var select2_liToHide = $(".select2-results__option[aria-disabled=true]")
-								        	for (li of select2_liToHide){
-								        	    $(li).css("display", "none")
-								        	}
-										});
-					    			}
+									let allOptionsWithParent = child.find("option");
+									let optionsByParent = multiSelectOptionsByParent[child_list];
+//									console.log(optionsByParent)
+									child.empty().select2({data: optionsByParent[parentVal]});
+					    		}
 				    		}
 				    	}
 				    	/**
 				        * Create event listeners on selects that depend on each other to hide them when they depend on
-				        * a parent that has no option selected, or to change their option list when the parents selection changes 
+				        * a parent that has no option selected, or to change their option list when the parents selection changes
 						*/
 						function setListDependencies() {
 					    	jQuery("select option[parent]").parent().each(function() {
-					    		var child_list = $(this).attr("id");
-								var parent = $(this).find("option[parent]:first").attr("parent");
-								var infos = parent.split(":");
-								var parent_list = infos[0];
-								//Hide daughters lists
-								if ($("#"+child_list).val() == 0 && $("#"+parent_list).val() == 0){
-								    var child = $("#"+child_list)
-								    //Hide children multiselects
-								    if($("#"+child_list).hasClass("multiselect")){
-								        $("span.select2-selection.select2-selection--multiple").hide()
+					    		let child_list = $(this).attr("id");
+					    		let child = $(this);
+								let parent_list = $(this).find("option[parent]:first").attr("parent").split(":")[0];
+//								console.log(parent_list)
+//								console.log(child_list)
+								let parent = $("#" + parent_list);
+								let hasEmptyVal = function ($select) {
+									let val = $select.val();
+									return val === "0" || (Array.isArray(val) && val.length === 0);
+								};
+								// Hide child lists
+								if (hasEmptyVal(child) && hasEmptyVal(parent)){
+								    if (child.hasClass("multiselect")) {
+								        child.next(".select2").hide();
 								    }
-								    $("#"+child_list).hide();
-
-								//Show mother lists
-								} else if ($("#"+parent_list).val() != 0){
-								    $("#"+parent_list).show();
-								    //show multiselects if its a parent one
-								    if($("#"+child_list).hasClass("multiselect")){
-								        $("span.select2-selection.select2-selection--multiple").show()
+								    child.hide();
+								// Show parent lists
+								} else if (parent.val() !== "0"){
+								    parent.show()
+								    if (child.hasClass("multiselect")) {
+								        child.next(".select2").show();
 								    }
 								}
-								//show the child list if the parent list value is selected
-								$("select[name=\""+parent_list+"\"]").click(function() {
-								    if ($(this).val() != 0){
-								        $("#"+child_list).show()
+								// show the child list if the parent list value is selected
+								parent.click(function() {
+								    if ($(this).val() !== 0){
+								        child.show()
 								        //show children multiselects if the parent list value is selected
-								        if($("#"+child_list).hasClass("multiselect")){
-								        	$("span.select2-selection.select2-selection--multiple").show()
+								        if(child.hasClass("multiselect")){
+								        	child.next(".select2").show()
 								    	}
 									}
 								});
-								$("select[name=\""+parent_list+"\"]").change(function() {
+								parent.change(function() {
 									showOptions(child_list, parent_list);
 									showOptionsOnMultiselect(child_list, parent_list)
-									$("#"+child_list).val(0).trigger("change");
-									//Hide child lists if the parent value is set to 0
+									child.val(0).trigger("change");
+									// Hide child lists if the parent value is set to 0
 									if ($(this).val() == 0){
-								   		$("#"+child_list).hide();
-								   		//Hide children multiselects
-								   		if($("#"+child_list).hasClass("multiselect")){
-								        	$("span.select2-selection.select2-selection--multiple").hide()
+								   		child.hide();
+								   		// Hide children multiselects
+								   		if(child.hasClass("multiselect")){
+								        	child.next(".select2").hide()
 								    	}
 									}
 								});
 					    	});
 						}
+						// create an object holding all multiselect options sorted by parent and by multiselect
+						let multiSelectOptionsByParent = {};
+						$("select.multiselect").each(function (n, select) {
+							if (!select.id) return;
+							let optionsByParent = {};
+							multiSelectOptionsByParent[select.id] = optionsByParent;
+							$(select).find("option").each(function (n, opt) {
+								let $opt = $(opt);
+								let parent = $opt.attr("parent") || "";
+								if (optionsByParent[parent] === undefined) optionsByParent[parent] = [];
+								optionsByParent[parent].push({
+									id: $opt.val(),
+									text: $opt.text(),
+								});
+//								console.log(optionsByParent)
+						    });
+						});
+//						console.log(multiSelectOptionsByParent)
 
 						setListDependencies();
 				    });

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6551,6 +6551,13 @@ abstract class CommonObject
 				$out .= '
 				<script>
 				    jQuery(document).ready(function() {
+
+				        /**
+				        * Make select options visible or invisible depending on what option is selected in the parent select
+				        *
+						* @param {string} child_list  Code of the child extrafield (starts with "options_")
+						* @param {string} parent_list Code of the parent extrafield (starts with "options_")
+						*/
 				    	function showOptions(child_list, parent_list)
 				    	{
 				    		var val = $("select[name=\""+parent_list+"\"]").val();
@@ -6569,6 +6576,12 @@ abstract class CommonObject
 								$("select[name=\""+child_list+"\"] option").show();
 							}
 				    	}
+				    	/**
+				        * Make multiselect options visible or invisible depending on what option is selected in the parent select
+				        *
+						* @param {string} child_list  Code of the child extrafield (starts with "options_")
+						* @param {string} parent_list Code of the parent extrafield (starts with "options_")
+						*/
 				    	function showOptionsOnMultiselect(child_list, parent_list){
 
 				    	    var val = $("select[name=\""+parent_list+"\"]").val();
@@ -6613,6 +6626,10 @@ abstract class CommonObject
 					    			}
 				    		}
 				    	}
+				    	/**
+				        * Create event listeners on selects that depend on each other to hide them when they depend on
+				        * a parent that has no option selected, or to change their option list when the parents selection changes 
+						*/
 						function setListDependencies() {
 					    	jQuery("select option[parent]").parent().each(function() {
 					    		var child_list = $(this).attr("id");

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6548,124 +6548,13 @@ abstract class CommonObject
 			$out .= "\n";
 			// Add code to manage list depending on others
 			if (! empty($conf->use_javascript_ajax)) {
+				$jsData = array("action" => $action);
 				$out .= '
-				<script>
-				    jQuery(document).ready(function() {
-
-				        /**
-				        * Make select options visible or invisible depending on what option is selected in the parent select
-				        *
-						* @param {string} child_list  Code of the child extrafield (starts with "options_")
-						* @param {string} parent_list Code of the parent extrafield (starts with "options_")
-						*/
-				    	function showOptions(child_list, parent_list)
-				    	{
-				    	    let child = $("select#" + child_list);
-				    	    let parent = $("select#" + parent_list);
-				    		let val = parent.val();
-				    		let parentVal = parent_list + ":" + val;
-							let childOptionsWithAParent = child.find("option[parent]");
-							let childOptionsWithSelectedParent = child.find("option[parent=\"" + parentVal + "\"]");
-				    		if(typeof val == "string"){
-				    		    if(val != "") {
-					    			childOptionsWithAParent.hide();
-					    			childOptionsWithSelectedParent.show();
-								} else {
-									child.find("option").show();
-								}
-				    		}
-				    	}
-				    	/**
-				        * Make multiselect options visible or invisible depending on what option is selected in the parent select
-				        *
-						* @param {string} child_list  Code of the child extrafield (starts with "options_")
-						* @param {string} parent_list Code of the parent extrafield (starts with "options_")
-						*/
-				    	function showOptionsOnMultiselect(child_list, parent_list){
-
-				    	    let val = $("select[name=\""+parent_list+"\"]").val();
-				    		let parentVal = parent_list + ":" + val;
-				    		let child = $("select#" + child_list);
-				    		if(typeof val == "string"){
-				    		    if(val !== "") {
-				    		        if($("#"+child_list).hasClass("multiselect")){
-										let optionsByParent = multiSelectOptionsByParent[child_list];
-										child.empty().select2({data: optionsByParent[parentVal]});
-					    			}
-		    		    		}
-				    		}
-				    	}
-				    	/**
-				        * Create event listeners on selects that depend on each other to hide them when they depend on
-				        * a parent that has no option selected, or to change their option list when the parents selection changes
-						*/
-						function setListDependencies() {
-					    	jQuery("select option[parent]").parent().each(function() {
-					    		let child_list = $(this).attr("id");
-					    		let child = $(this);
-								let parent_list = $(this).find("option[parent]:first").attr("parent").split(":")[0];
-								let parent = $("#" + parent_list);
-								let hasEmptyVal = function ($select) {
-									let val = $select.val();
-									return val === "0" || (Array.isArray(val) && val.length === 0);
-								};
-								// Hide child lists
-								if (hasEmptyVal(child) && hasEmptyVal(parent)){
-								    if (child.hasClass("multiselect")) {
-								        child.next(".select2").hide();
-								    }
-								    child.hide();
-								// Show parent lists
-								} else if (parent.val() !== "0"){
-								    parent.show()
-								    if (child.hasClass("multiselect")) {
-								        child.next(".select2").show();
-								    }
-								}
-								// show the child list if the parent list value is selected
-								parent.click(function() {
-								    if ($(this).val() !== 0){
-								        child.show()
-								        //show children multiselects if the parent list value is selected
-								        if(child.hasClass("multiselect")){
-								        	child.next(".select2").show()
-								    	}
-									}
-								});
-								parent.change(function() {
-									showOptions(child_list, parent_list);
-									showOptionsOnMultiselect(child_list, parent_list)
-									child.val(0).trigger("change");
-									// Hide child lists if the parent value is set to 0
-									if ($(this).val() == 0){
-								   		child.hide();
-								   		// Hide children multiselects
-								   		if(child.hasClass("multiselect")){
-								        	child.next(".select2").hide()
-								    	}
-									}
-								});
-					    	});
-						}
-						// create an object holding all multiselect options sorted by parent and by multiselect
-						let multiSelectOptionsByParent = {};
-						$("select.multiselect").each(function (n, select) {
-							if (!select.id) return;
-							let optionsByParent = {};
-							multiSelectOptionsByParent[select.id] = optionsByParent;
-							$(select).find("option").each(function (n, opt) {
-								let $opt = $(opt);
-								let parent = $opt.attr("parent") || "";
-								if (optionsByParent[parent] === undefined) optionsByParent[parent] = [];
-								optionsByParent[parent].push({
-									id: $opt.val(),
-									text: $opt.text(),
-								});
-						    });
-						});
-
-						setListDependencies();
-				    });
+				<script type="text/javascript" src="/dolibarr/htdocs/core/js/lib_extrafields.js"></script>
+				<script type="text/javascript">
+				$(document).ready(function() {
+				   	manageLinkedExtrafields('.json_encode($jsData).');
+				})
 				</script>'."\n";
 				$out .= '<!-- /showOptionalsInput --> '."\n";
 			}

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6573,12 +6573,6 @@ abstract class CommonObject
 								} else {
 									child.find("option").show();
 								}
-				    		} else if(val > 0) {
-					    		childOptionsWithAParent.hide();
-					    			childOptionsWithSelectedParent.show();
-								} else {
-									child.find("option").show();
-								}
 				    	}
 				    	/**
 				        * Make multiselect options visible or invisible depending on what option is selected in the parent select
@@ -6591,26 +6585,13 @@ abstract class CommonObject
 				    	    let val = $("select[name=\""+parent_list+"\"]").val();
 				    		let parentVal = parent_list + ":" + val;
 				    		let child = $("select#" + child_list);
-//				    		console.log(parentVal)
-//				    		console.log(child_list);
 				    		if(typeof val == "string"){
 				    		    if(val !== "") {
 				    		        if($("#"+child_list).hasClass("multiselect")){
-										let allOptionsWithParent = child.find("option");
-										console.log(multiSelectOptionsByParent)
 										let optionsByParent = multiSelectOptionsByParent[child_list];
-//										console.log(multiSelectOptionsByParent[child_list])
-//										console.log(optionsByParent[parentVal])
 										child.empty().select2({data: optionsByParent[parentVal]});
 					    			}
 		    		    		}
-				    		} else if(val > 0) {
-				    		    if($("#"+child_list).hasClass("multiselect")){
-									let allOptionsWithParent = child.find("option");
-									let optionsByParent = multiSelectOptionsByParent[child_list];
-//									console.log(optionsByParent)
-									child.empty().select2({data: optionsByParent[parentVal]});
-					    		}
 				    		}
 				    	}
 				    	/**

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6573,6 +6573,7 @@ abstract class CommonObject
 								} else {
 									child.find("option").show();
 								}
+				    		}
 				    	}
 				    	/**
 				        * Make multiselect options visible or invisible depending on what option is selected in the parent select

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6603,8 +6603,6 @@ abstract class CommonObject
 					    		let child_list = $(this).attr("id");
 					    		let child = $(this);
 								let parent_list = $(this).find("option[parent]:first").attr("parent").split(":")[0];
-//								console.log(parent_list)
-//								console.log(child_list)
 								let parent = $("#" + parent_list);
 								let hasEmptyVal = function ($select) {
 									let val = $select.val();
@@ -6662,10 +6660,8 @@ abstract class CommonObject
 									id: $opt.val(),
 									text: $opt.text(),
 								});
-//								console.log(optionsByParent)
 						    });
 						});
-//						console.log(multiSelectOptionsByParent)
 
 						setListDependencies();
 				    });

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6555,24 +6555,109 @@ abstract class CommonObject
 				    	{
 				    		var val = $("select[name=\""+parent_list+"\"]").val();
 				    		var parentVal = parent_list + ":" + val;
-							if(val > 0) {
+				    		if(typeof val == "string"){
+				    		    if(val != "") {
+					    			$("select[name=\""+child_list+"\"] option[parent]").hide();
+					    			$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
+								} else {
+									$("select[name=\""+child_list+"\"] option").show();
+								}
+				    		} else if(val > 0) {
 					    		$("select[name=\""+child_list+"\"] option[parent]").hide();
 					    		$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
 							} else {
 								$("select[name=\""+child_list+"\"] option").show();
 							}
 				    	}
+				    	function showOptionsOnMultiselect(child_list, parent_list){
+
+				    	    var val = $("select[name=\""+parent_list+"\"]").val();
+				    		var parentVal = parent_list + ":" + val;
+				    		if(typeof val == "string"){
+				    		    if(val != "") {
+				    		        if($("#"+child_list).hasClass("multiselect")){
+								     	var allOptionsWithParent = $("select[id=\""+child_list+"\"] option")
+								        var optionsToShow = $("select[id=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
+								        $("#"+child_list).select2();
+								        for (option of allOptionsWithParent){
+								            option.disabled = true;
+								        }
+								        for (option of optionsToShow){
+								            option.disabled = false;
+								        }
+								        $("span.select2-selection.select2-selection--multiple").click(function() {
+								        	var select2_liToHide = $(".select2-results__option[aria-disabled=true]")
+								        	for (li of select2_liToHide){
+								        	    $(li).css("display", "none")
+								        	}
+										});
+					    			}
+		    		    		}
+				    		} else if(val > 0) {
+				    		    if($("#"+child_list).hasClass("multiselect")){
+								     	var allOptionsWithParent = $("select[id=\""+child_list+"\"] option")
+								        var optionsToShow = $("select[id=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
+								     	$("#"+child_list).select2();
+								        for (option of allOptionsWithParent){
+								            option.disabled = true;
+								        }
+								        for (option of optionsToShow){
+								            option.disabled = false;
+								        }
+								        $("span.select2-selection.select2-selection--multiple").click(function() {
+								            var select2_liToHide = $(".select2-results__option[aria-disabled=true]")
+								        	for (li of select2_liToHide){
+								        	    $(li).css("display", "none")
+								        	}
+										});
+					    			}
+				    		}
+				    	}
 						function setListDependencies() {
 					    	jQuery("select option[parent]").parent().each(function() {
-					    		var child_list = $(this).attr("name");
+					    		var child_list = $(this).attr("id");
 								var parent = $(this).find("option[parent]:first").attr("parent");
 								var infos = parent.split(":");
 								var parent_list = infos[0];
-								showOptions(child_list, parent_list);
+								//Hide daughters lists
+								if ($("#"+child_list).val() == 0 && $("#"+parent_list).val() == 0){
+								    var child = $("#"+child_list)
+								    //Hide children multiselects
+								    if($("#"+child_list).hasClass("multiselect")){
+								        $("span.select2-selection.select2-selection--multiple").hide()
+								    }
+								    $("#"+child_list).hide();
 
-								/* Activate the handler to call showOptions on each future change */
+								//Show mother lists
+								} else if ($("#"+parent_list).val() != 0){
+								    $("#"+parent_list).show();
+								    //show multiselects if its a parent one
+								    if($("#"+child_list).hasClass("multiselect")){
+								        $("span.select2-selection.select2-selection--multiple").show()
+								    }
+								}
+								//show the child list if the parent list value is selected
+								$("select[name=\""+parent_list+"\"]").click(function() {
+								    if ($(this).val() != 0){
+								        $("#"+child_list).show()
+								        //show children multiselects if the parent list value is selected
+								        if($("#"+child_list).hasClass("multiselect")){
+								        	$("span.select2-selection.select2-selection--multiple").show()
+								    	}
+									}
+								});
 								$("select[name=\""+parent_list+"\"]").change(function() {
 									showOptions(child_list, parent_list);
+									showOptionsOnMultiselect(child_list, parent_list)
+									$("#"+child_list).val(0).trigger("change");
+									//Hide child lists if the parent value is set to 0
+									if ($(this).val() == 0){
+								   		$("#"+child_list).hide();
+								   		//Hide children multiselects
+								   		if($("#"+child_list).hasClass("multiselect")){
+								        	$("span.select2-selection.select2-selection--multiple").hide()
+								    	}
+									}
 								});
 					    	});
 						}
@@ -7780,5 +7865,5 @@ abstract class CommonObject
 
 		$this->db->commit();
 		return true;
-	}
+    }
 }

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1775,6 +1775,10 @@ class ExtraFields
 			if (is_array($value_arr))
 			{
 				foreach ($value_arr as $keyval=>$valueval) {
+					if (sizeof(explode('|', $param['options'][$valueval])) == 2 ){
+						$value_detail = explode('|', $param['options'][$valueval]);
+						$param['options'][$valueval] = $value_detail[0];
+					}
 					$toprint[]='<li class="select2-search-choice-dolibarr noborderoncategories" style="background: #aaa">'.$param['options'][$valueval].'</li>';
 				}
 			}

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1678,8 +1678,13 @@ class ExtraFields
 		}
 		elseif ($type == 'select')
 		{
-			if ($langfile && $param['options'][$value]) $value=$langs->trans($param['options'][$value]);
-			else $value=$param['options'][$value];
+			if ($langfile && $param['options'][$value]) {
+
+				$value=$langs->trans($param['options'][$value]);
+			}else if (sizeof(explode('|', $param['options'][$value])) > 1){
+				$value_detail = explode('|', $param['options'][$value]);
+				$value = $value_detail[0];
+			} else $value=$param['options'][$value];
 		}
 		elseif ($type == 'sellist')
 		{
@@ -1991,7 +1996,6 @@ class ExtraFields
 
 				$key_type = $this->attributes[$object->table_element]['type'][$key];
 				if ($key_type == 'separate') continue;
-
 				$enabled = 1;
 				if (isset($this->attributes[$object->table_element]['list'][$key]))
 				{

--- a/htdocs/core/class/extrafields.class.php
+++ b/htdocs/core/class/extrafields.class.php
@@ -1258,7 +1258,7 @@ class ExtraFields
                     dol_syslog(get_class($this) . '::showInputField type=sellist', LOG_DEBUG);
                     $resql = $this->db->query($sql);
                     if ($resql) {
-						$out .= '<option value="0">&nbsp;</option>';
+                        $out .= '<option value="0">&nbsp;</option>';
                         $num = $this->db->num_rows($resql);
                         $i = 0;
                         while ($i < $num) {
@@ -1323,7 +1323,7 @@ class ExtraFields
                 } else {
 					require_once DOL_DOCUMENT_ROOT . '/categories/class/categorie.class.php';
                     $data = $form->select_all_categories(Categorie::$MAP_ID_TO_CODE[$InfoFieldList[5]], '', 'parent', 64, $InfoFieldList[6], 1, 1);
-					$out .= '<option value="0">&nbsp;</option>';
+                    $out .= '<option value="0">&nbsp;</option>';
                     foreach ($data as $data_key => $data_value) {
                         $out .= '<option value="' . $data_key . '"';
                         $out .= ($value == $data_key ? ' selected' : '');
@@ -2010,7 +2010,7 @@ class ExtraFields
 					// Check if empty without using GETPOST, value can be alpha, int, array, etc...
 				    if ((! is_array($_POST["options_".$key]) && empty($_POST["options_".$key]) && !in_array($this->attributes[$object->table_element]['type'][$key], array('select', 'sellist')) && $_POST["options_".$key] != '0')
 				        || (! is_array($_POST["options_".$key]) && empty($_POST["options_".$key]) && in_array($this->attributes[$object->table_element]['type'][$key], array('select', 'sellist')))
-				        || (is_array($_POST["options_".$key]) && empty($_POST["options_".$key])))
+						|| (is_array($_POST["options_".$key]) && empty($_POST["options_".$key])))
 					{
 						//print 'ccc'.$value.'-'.$this->attributes[$object->table_element]['required'][$key];
 						$nofillrequired++;

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6334,6 +6334,7 @@ class Form
 					if (sizeof(explode("|", $value)) == 2){
 						$info = explode("|", $value);
 						$out.= '<option value="'.$key.'" parent="'.$info[1].'"';
+						$value = $info[0];
 					} else {
 						$out .= '<option value="' . $key . '"';
 					}
@@ -6342,7 +6343,7 @@ class Form
 						$out.= ' selected';
 					}
 					$out.= '>';
-					$newval = ($translate ? $langs->trans($info[0]) : $info[0]);
+					$newval = ($translate ? $langs->trans($value) : $value);
 					$newval = ($key_in_label ? $key.' - '.$newval : $newval);
 					$out.= dol_htmlentitiesbr($newval);
 					$out.= '</option>'."\n";

--- a/htdocs/core/class/html.form.class.php
+++ b/htdocs/core/class/html.form.class.php
@@ -6331,14 +6331,18 @@ class Form
 			{
 				foreach ($array as $key => $value)
 				{
-					$out.= '<option value="'.$key.'"';
+					if (sizeof(explode("|", $value)) == 2){
+						$info = explode("|", $value);
+						$out.= '<option value="'.$key.'" parent="'.$info[1].'"';
+					} else {
+						$out .= '<option value="' . $key . '"';
+					}
                     if (is_array($selected) && ! empty($selected) && in_array((string) $key, $selected) && ((string) $key != ''))
 					{
 						$out.= ' selected';
 					}
 					$out.= '>';
-
-					$newval = ($translate ? $langs->trans($value) : $value);
+					$newval = ($translate ? $langs->trans($info[0]) : $info[0]);
 					$newval = ($key_in_label ? $key.' - '.$newval : $newval);
 					$out.= dol_htmlentitiesbr($newval);
 					$out.= '</option>'."\n";

--- a/htdocs/core/js/lib_extrafields.js
+++ b/htdocs/core/js/lib_extrafields.js
@@ -1,0 +1,134 @@
+
+function manageLinkedExtrafields(data){
+
+	/**
+	 * Make select options visible or invisible depending on what option is selected in the parent select
+	 *
+	 * @param {string} child_list  Code of the child extrafield (starts with "options_")
+	 * @param {string} parent_list Code of the parent extrafield (starts with "options_")
+	 */
+	function showOptions(child_list, parent_list)
+	{
+		let child = $("select#" + child_list);
+		let parent = $("select#" + parent_list);
+		let val = 0;
+		if (data["action"] === "create"){
+			val = parent.val();
+		} else if (data["action"] === "edit_extras"){
+			let infos = parent_list.split("_");
+			val = $("#"+data["table_element"]+"_extras_"+infos[1]+"_"+ data["object_id"]).attr("data-value");
+		}
+		let parentVal = parent_list + ":" + val;
+		let childOptionsWithAParent = child.find("option[parent]");
+		let childOptionsWithSelectedParent = child.find("option[parent='"+parentVal+"']");
+		if(typeof val == "string"){
+			if(val != "") {
+				childOptionsWithAParent.hide();
+				childOptionsWithSelectedParent.show();
+			} else {
+				child.find("option").show();
+			}
+		}
+	}
+	/**
+	 * Make multiselect options visible or invisible depending on what option is selected in the parent select
+	 *
+	 * @param {string} child_list  Code of the child extrafield (starts with "options_")
+	 * @param {string} parent_list Code of the parent extrafield (starts with "options_")
+	 */
+	function showOptionsOnMultiselect(child_list, parent_list){
+		let val = 0;
+		if (data["action"] === "create"){
+			val = $("select[name=\""+parent_list+"\"]").val();
+		} else if (data["action"] === "edit_extras"){
+			let infos = parent_list.split("_");
+			val = $("#"+data["table_element"]+"_extras_"+infos[1]+"_"+ data["object_id"]).attr("data-value");
+		}
+		let parentVal = parent_list + ":" + val;
+		let child = $("select#" + child_list);
+		if(typeof val == "string"){
+			if(val !== "") {
+				if($("#"+child_list).hasClass("multiselect")){
+					let optionsByParent = multiSelectOptionsByParent[child_list];
+					child.empty().select2({data: optionsByParent[parentVal]});
+				}
+			}
+		}
+	}
+	/**
+	 * Create event listeners on selects that depend on each other to hide them when they depend on
+	 * a parent that has no option selected, or to change their option list when the parents selection changes
+	 */
+	function setListDependencies() {
+		jQuery("select option[parent]").parent().each(function() {
+			let child_list = $(this).attr("id");
+			let child = $("#" + child_list);
+			let parent_list = $(this).find("option[parent]:first").attr("parent").split(":")[0];
+			let parent = $("#" + parent_list);
+			let hasEmptyVal = function ($select) {
+				let val = $select.val();
+				return val === "0" || (Array.isArray(val) && val.length === 0);
+			};
+			// Hide child lists
+			if (hasEmptyVal(child) && hasEmptyVal(parent)){
+				if (child.hasClass("multiselect")) {
+					child.next(".select2").hide();
+				}
+				child.hide();
+			// Show parent lists
+			} else if (parent.val() !== "0"){
+				// parent.show()
+				if (child.hasClass("multiselect")) {
+					child.next(".select2").show();
+				} else {
+					child.show();
+				}
+			}
+			// show the child list if the parent list value is selected
+			parent.click(function() {
+				if ($(this).val() !== "0"){
+					child.show();
+					//show children multiselects if the parent list value is selected
+					if(child.hasClass("multiselect")){
+						child.next(".select2").show();
+					}
+				}
+			});
+			if (data["action"] === "edit_extras"){
+				showOptions(child_list, parent_list);
+				showOptionsOnMultiselect(child_list, parent_list)
+			}
+			parent.change(function() {
+				showOptions(child_list, parent_list);
+				showOptionsOnMultiselect(child_list, parent_list)
+				child.val(0).trigger("change");
+				// Hide child lists if the parent value is set to 0
+				if (hasEmptyVal(parent)){
+					// Hide children multiselects
+					if(child.hasClass("multiselect")){
+						child.next(".select2").hide();
+					}
+					child.hide();
+				}
+			});
+		});
+	}
+	// create an object holding all multiselect options sorted by parent and by multiselect
+	let multiSelectOptionsByParent = {};
+	$("select.multiselect").each(function (n, select) {
+		if (!select.id) return;
+		let optionsByParent = {};
+		multiSelectOptionsByParent[select.id] = optionsByParent;
+		$(select).find("option").each(function (n, opt) {
+			let $opt = $(opt);
+			let parent = $opt.attr("parent") || "";
+			if (optionsByParent[parent] === undefined) optionsByParent[parent] = [];
+			optionsByParent[parent].push({
+				id: $opt.val(),
+				text: $opt.text(),
+			});
+		});
+	});
+
+	setListDependencies();
+}

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -185,7 +185,6 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 				    	    let infos = parent_list.split("_");
 				    		let val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').attr("value");
 				    		let parentVal = parent_list + ":" + val;
-				    		console.log(val)
 							let childOptionsWithAParent = child.find("option[parent]");
 							let childOptionsWithSelectedParent = child.find("option[parent=\"" + parentVal + "\"]");
 				    		if(typeof val == "string"){

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -200,6 +200,51 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 								$("select[name=\""+child_list+"\"] option").show();
 							}
 				    	}
+
+				    	function showOptionsOnMultiselect(child_list, parent_list){
+				    		console.log("weshtamr")
+				    	    var val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').text();
+				    		var parentVal = parent_list + ":" + val;
+				    		if(typeof val == "string"){
+				    		    if(val != "") {
+				    		        if($("#"+child_list).hasClass("multiselect")){
+								     	var allOptionsWithParent = $("select[id=\""+child_list+"\"] option")
+								        var optionsToShow = $("select[id=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
+								        $("#"+child_list).select2();
+								        for (option of allOptionsWithParent){
+								            option.disabled = true;
+								        }
+								        for (option of optionsToShow){
+								            option.disabled = false;
+								        }
+								        $("span.select2-selection.select2-selection--multiple").click(function() {
+								        	var select2_liToHide = $(".select2-results__option[aria-disabled=true]")
+								        	for (li of select2_liToHide){
+								        	    $(li).css("display", "none")
+								        	}
+										});
+					    			}
+		    		    		}
+				    		} else if(val > 0) {
+				    		    if($("#"+child_list).hasClass("multiselect")){
+								     	var allOptionsWithParent = $("select[id=\""+child_list+"\"] option")
+								        var optionsToShow = $("select[id=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
+								        for (option of allOptionsWithParent){
+								            option.disabled = true;
+								        }
+								        for (option of optionsToShow){
+								            option.disabled = false;
+								        }
+								        $("span.select2-selection.select2-selection--multiple").click(function() {
+								            var select2_liToHide = $(".select2-results__option[aria-disabled=true]")
+								        	for (li of select2_liToHide){
+								        	    $(li).css("display", "none")
+								        	}
+										});
+					    			}
+				    		}
+				    	}
+
 						function setListDependencies() {
 					    	jQuery("select option[parent]").parent().each(function() {
 					    		var child_list = $(this).attr("name");
@@ -213,6 +258,7 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 								var searchparams = new URLSearchParams(window.location.href);
 								if (searchparams.get("action") == "edit_extras"){
 									showOptions(child_list, parent_list);
+									showOptionsOnMultiselect(child_list, parent_list);
 								}
 					    	});
 						}

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -177,13 +177,23 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 	{
 		print "\n";
 		print '
-				<script type="text/javascript">
+				<script>
 				    jQuery(document).ready(function() {
 				    	function showOptions(child_list, parent_list)
 				    	{
-				    		var val = $("select[name="+parent_list+"]").val();
+				    	    var params = new URLSearchParams(window.location.href);
+							var infos = parent_list.split("_");
+							//Selection of the DOM element
+				    		var val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').text();
 				    		var parentVal = parent_list + ":" + val;
-							if(val > 0) {
+				    		if(typeof val == "string"){
+				    		    if(val != "") {
+					    			$("select[name=\""+child_list+"\"] option[parent]").hide();
+					    			$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
+								} else {
+									$("select[name=\""+child_list+"\"] option").show();
+								}
+				    		} else if(val > 0) {
 					    		$("select[name=\""+child_list+"\"] option[parent]").hide();
 					    		$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
 							} else {
@@ -196,12 +206,14 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 								var parent = $(this).find("option[parent]:first").attr("parent");
 								var infos = parent.split(":");
 								var parent_list = infos[0];
-								showOptions(child_list, parent_list);
-
-								/* Activate the handler to call showOptions on each future change */
-								$("select[name=\""+parent_list+"\"]").change(function() {
+								var code_parent = parent_list.split("-")
+								console.log(child_list)
+								console.log(parent_list)
+								$("#propal_extras_type3_23").val("")
+								var searchparams = new URLSearchParams(window.location.href);
+								if (searchparams.get("action") == "edit_extras"){
 									showOptions(child_list, parent_list);
-								});
+								}
 					    	});
 						}
 						setListDependencies();

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -129,7 +129,7 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 
 			$html_id = !empty($object->id) ? $object->element.'_extras_'.$key.'_'.$object->id : '';
 
-			print '<td id="'.$html_id.'" value="'.$value.'"class="'.$object->element.'_extras_'.$key.' wordbreak"'.($cols?' colspan="'.$cols.'"':'').'>';
+			print '<td id="'.$html_id.'" data-value="'.$value.'"class="'.$object->element.'_extras_'.$key.' wordbreak"'.($cols?' colspan="'.$cols.'"':'').'>';
 
 			// Convert date into timestamp format
 			if (in_array($extrafields->attributes[$object->table_element]['type'][$key], array('date','datetime')))
@@ -175,74 +175,20 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 	// TODO Test/enhance this with a more generic solution
 	if (! empty($conf->use_javascript_ajax))
 	{
+		$jsData = array(
+			"action" => $action,
+			"table_element" => $object->table_element,
+			"object_id" => $object->id
+		);
+
 		print "\n";
 		print '
-				<script>
-				    jQuery(document).ready(function() {
-				    	function showOptions(child_list, parent_list)
-				    	{
-							let child = $("select#" + child_list);
-				    	    let infos = parent_list.split("_");
-				    		let val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').attr("value");
-				    		let parentVal = parent_list + ":" + val;
-							let childOptionsWithAParent = child.find("option[parent]");
-							let childOptionsWithSelectedParent = child.find("option[parent=\"" + parentVal + "\"]");
-				    		if(typeof val == "string"){
-				    		    if(val != "") {
-					    			childOptionsWithAParent.hide();
-					    			childOptionsWithSelectedParent.show();
-								} else {
-									child.find("option").show();
-								}
-				    		}
-				    	}
-
-				    	function showOptionsOnMultiselect(child_list, parent_list){
-							let infos = parent_list.split("_");
-				    	    let val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').attr("value");
-				    		let parentVal = parent_list + ":" + val;
-				    		let child = $("select#" + child_list);
-				    		if(typeof val == "string"){
-				    		    if(val != "") {
-				    		        if($("#"+child_list).hasClass("multiselect")){
-										let optionsByParent = multiSelectOptionsByParent[child_list];
-										child.empty().select2({data: optionsByParent[parentVal]});
-					    			}
-		    		    		}
-				    		}
-				    	}
-
-						function setListDependencies() {
-					    	jQuery("select option[parent]").parent().each(function() {
-					    		var child_list = $(this).attr("id");
-								let parent_list = $(this).find("option[parent]:first").attr("parent").split(":")[0];
-								var searchparams = new URLSearchParams(window.location.href);
-								if (searchparams.get("action") == "edit_extras"){
-									showOptions(child_list, parent_list);
-									showOptionsOnMultiselect(child_list, parent_list);
-								}
-					    	});
-						}
-						// create an object holding all multiselect options sorted by parent and by multiselect
-						let multiSelectOptionsByParent = {};
-						$("select.multiselect").each(function (n, select) {
-							if (!select.id) return;
-							let optionsByParent = {};
-							multiSelectOptionsByParent[select.id] = optionsByParent;
-							$(select).find("option").each(function (n, opt) {
-								let $opt = $(opt);
-								let parent = $opt.attr("parent") || "";
-								if (optionsByParent[parent] === undefined) optionsByParent[parent] = [];
-								optionsByParent[parent].push({
-									id: $opt.val(),
-									text: $opt.text(),
-								});
-						    });
-						});
-
-						setListDependencies();
-				    });
-				</script>'."\n";
+				<script type="text/javascript" src="/dolibarr/htdocs/core/js/lib_extrafields.js"></script>
+				<script type="text/javascript">
+				$(document).ready(function() {
+					manageLinkedExtrafields('.json_encode($jsData).');
+				});
+				</script>';
 	}
 }
 ?>

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -204,7 +204,6 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 							var infos = parent_list.split("_");
 				    	    var val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').text();
 				    		var parentVal = parent_list + ":" + val;
-
 				    		if(typeof val == "string"){
 				    		    if(val != "") {
 				    		        if($("select[name=\""+child_list+"\"]").hasClass("multiselect")){
@@ -217,8 +216,6 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 								        for (option of optionsToShow){
 								            option.disabled = false;
 								        }
-								        console.log(optionsToShow)
-								        console.log($("span.select2-selection.select2-selection--multiple"))
 								        $("span.select2-selection.select2-selection--multiple").click(function() {
 								        	var select2_liToHide = $(".select2-results__option[aria-disabled=true]")
 								        	for (li of select2_liToHide){
@@ -231,6 +228,7 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 				    		    if($("#"+child_list).hasClass("multiselect")){
 								     	var allOptionsWithParent = $("select[id=\""+child_list+"\"] option")
 								        var optionsToShow = $("select[id=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
+								        $("select[name=\""+child_list+"\"]").select2();
 								        for (option of allOptionsWithParent){
 								            option.disabled = true;
 								        }

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -181,7 +181,6 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 				    jQuery(document).ready(function() {
 				    	function showOptions(child_list, parent_list)
 				    	{
-				    	    var params = new URLSearchParams(window.location.href);
 							var infos = parent_list.split("_");
 							//Selection of the DOM element
 				    		var val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').text();
@@ -202,21 +201,24 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 				    	}
 
 				    	function showOptionsOnMultiselect(child_list, parent_list){
-				    		console.log("weshtamr")
+							var infos = parent_list.split("_");
 				    	    var val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').text();
 				    		var parentVal = parent_list + ":" + val;
+
 				    		if(typeof val == "string"){
 				    		    if(val != "") {
-				    		        if($("#"+child_list).hasClass("multiselect")){
-								     	var allOptionsWithParent = $("select[id=\""+child_list+"\"] option")
-								        var optionsToShow = $("select[id=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
-								        $("#"+child_list).select2();
+				    		        if($("select[name=\""+child_list+"\"]").hasClass("multiselect")){
+								     	var allOptionsWithParent = $("select[name=\""+child_list+"\"] option")
+								        var optionsToShow = $("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
+								        $("select[name=\""+child_list+"\"]").select2();
 								        for (option of allOptionsWithParent){
 								            option.disabled = true;
 								        }
 								        for (option of optionsToShow){
 								            option.disabled = false;
 								        }
+								        console.log(optionsToShow)
+								        console.log($("span.select2-selection.select2-selection--multiple"))
 								        $("span.select2-selection.select2-selection--multiple").click(function() {
 								        	var select2_liToHide = $(".select2-results__option[aria-disabled=true]")
 								        	for (li of select2_liToHide){
@@ -252,9 +254,6 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 								var infos = parent.split(":");
 								var parent_list = infos[0];
 								var code_parent = parent_list.split("-")
-								console.log(child_list)
-								console.log(parent_list)
-								$("#propal_extras_type3_23").val("")
 								var searchparams = new URLSearchParams(window.location.href);
 								if (searchparams.get("action") == "edit_extras"){
 									showOptions(child_list, parent_list);

--- a/htdocs/core/tpl/extrafields_view.tpl.php
+++ b/htdocs/core/tpl/extrafields_view.tpl.php
@@ -129,7 +129,7 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 
 			$html_id = !empty($object->id) ? $object->element.'_extras_'.$key.'_'.$object->id : '';
 
-			print '<td id="'.$html_id.'" class="'.$object->element.'_extras_'.$key.' wordbreak"'.($cols?' colspan="'.$cols.'"':'').'>';
+			print '<td id="'.$html_id.'" value="'.$value.'"class="'.$object->element.'_extras_'.$key.' wordbreak"'.($cols?' colspan="'.$cols.'"':'').'>';
 
 			// Convert date into timestamp format
 			if (in_array($extrafields->attributes[$object->table_element]['type'][$key], array('date','datetime')))
@@ -181,77 +181,42 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 				    jQuery(document).ready(function() {
 				    	function showOptions(child_list, parent_list)
 				    	{
-							var infos = parent_list.split("_");
-							//Selection of the DOM element
-				    		var val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').text();
-				    		var parentVal = parent_list + ":" + val;
+							let child = $("select#" + child_list);
+				    	    let infos = parent_list.split("_");
+				    		let val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').attr("value");
+				    		let parentVal = parent_list + ":" + val;
+				    		console.log(val)
+							let childOptionsWithAParent = child.find("option[parent]");
+							let childOptionsWithSelectedParent = child.find("option[parent=\"" + parentVal + "\"]");
 				    		if(typeof val == "string"){
 				    		    if(val != "") {
-					    			$("select[name=\""+child_list+"\"] option[parent]").hide();
-					    			$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
+					    			childOptionsWithAParent.hide();
+					    			childOptionsWithSelectedParent.show();
 								} else {
-									$("select[name=\""+child_list+"\"] option").show();
+									child.find("option").show();
 								}
-				    		} else if(val > 0) {
-					    		$("select[name=\""+child_list+"\"] option[parent]").hide();
-					    		$("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]").show();
-							} else {
-								$("select[name=\""+child_list+"\"] option").show();
-							}
+				    		}
 				    	}
 
 				    	function showOptionsOnMultiselect(child_list, parent_list){
-							var infos = parent_list.split("_");
-				    	    var val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').text();
-				    		var parentVal = parent_list + ":" + val;
+							let infos = parent_list.split("_");
+				    	    let val = $("#'.$object->table_element.'_extras_"+infos[1]+"_"'."+". $object->id.').attr("value");
+				    		let parentVal = parent_list + ":" + val;
+				    		let child = $("select#" + child_list);
 				    		if(typeof val == "string"){
 				    		    if(val != "") {
-				    		        if($("select[name=\""+child_list+"\"]").hasClass("multiselect")){
-								     	var allOptionsWithParent = $("select[name=\""+child_list+"\"] option")
-								        var optionsToShow = $("select[name=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
-								        $("select[name=\""+child_list+"\"]").select2();
-								        for (option of allOptionsWithParent){
-								            option.disabled = true;
-								        }
-								        for (option of optionsToShow){
-								            option.disabled = false;
-								        }
-								        $("span.select2-selection.select2-selection--multiple").click(function() {
-								        	var select2_liToHide = $(".select2-results__option[aria-disabled=true]")
-								        	for (li of select2_liToHide){
-								        	    $(li).css("display", "none")
-								        	}
-										});
+				    		        if($("#"+child_list).hasClass("multiselect")){
+										let optionsByParent = multiSelectOptionsByParent[child_list];
+										child.empty().select2({data: optionsByParent[parentVal]});
 					    			}
 		    		    		}
-				    		} else if(val > 0) {
-				    		    if($("#"+child_list).hasClass("multiselect")){
-								     	var allOptionsWithParent = $("select[id=\""+child_list+"\"] option")
-								        var optionsToShow = $("select[id=\""+child_list+"\"] option[parent=\""+parentVal+"\"]");
-								        $("select[name=\""+child_list+"\"]").select2();
-								        for (option of allOptionsWithParent){
-								            option.disabled = true;
-								        }
-								        for (option of optionsToShow){
-								            option.disabled = false;
-								        }
-								        $("span.select2-selection.select2-selection--multiple").click(function() {
-								            var select2_liToHide = $(".select2-results__option[aria-disabled=true]")
-								        	for (li of select2_liToHide){
-								        	    $(li).css("display", "none")
-								        	}
-										});
-					    			}
 				    		}
 				    	}
 
 						function setListDependencies() {
 					    	jQuery("select option[parent]").parent().each(function() {
-					    		var child_list = $(this).attr("name");
-								var parent = $(this).find("option[parent]:first").attr("parent");
-								var infos = parent.split(":");
-								var parent_list = infos[0];
-								var code_parent = parent_list.split("-")
+					    		var child_list = $(this).attr("id");
+								let parent_list = $(this).find("option[parent]:first").attr("parent").split(":")[0];
 								var searchparams = new URLSearchParams(window.location.href);
 								if (searchparams.get("action") == "edit_extras"){
 									showOptions(child_list, parent_list);
@@ -259,6 +224,23 @@ if (empty($reshook) && is_array($extrafields->attributes[$object->table_element]
 								}
 					    	});
 						}
+						// create an object holding all multiselect options sorted by parent and by multiselect
+						let multiSelectOptionsByParent = {};
+						$("select.multiselect").each(function (n, select) {
+							if (!select.id) return;
+							let optionsByParent = {};
+							multiSelectOptionsByParent[select.id] = optionsByParent;
+							$(select).find("option").each(function (n, opt) {
+								let $opt = $(opt);
+								let parent = $opt.attr("parent") || "";
+								if (optionsByParent[parent] === undefined) optionsByParent[parent] = [];
+								optionsByParent[parent].push({
+									id: $opt.val(),
+									text: $opt.text(),
+								});
+						    });
+						});
+
 						setListDependencies();
 				    });
 				</script>'."\n";


### PR DESCRIPTION
## FIX : Système de champs complémentaire liés : listes et multiselect 

**Dans Dolibarr, il est possible de créer des extrafields de type "Case à cocher" (multiselect) dépendant d'extrafields de type "Liste déroulante". Cependant, ce système ne fonctionne pas correctement, en effet, il y avait quelques problème concernant l'affichage des bonnes options :**
- Les options sont désormais affichées correctement, en fonction de la valeur sélectionnée dans la liste parente
- Il y avait des problèmes concernant l'affichage des valeurs résultat (valeurs sélectionnées et validées) sur la carte en mode "View" : les champs sont désormais correctement affichés  
- Le multiselect n'est pas affiché tant que la valeur de sa liste parente n'est pas saisie 
- Le multiselect est vidé sur changement de la valeur sélectionnée dans la liste parente 
- Sur update des valeurs résultat (depuis la carte en mode "View"), les options n'étaient pas les bonnes, desormais ça l'est 

**Néanmoins, il y a quelques restrictions :** 
- Ce système ne fonctionne pas dans le cas d'un multiselect dépendant d'un autre multiselect 
- Ce système fonctionne pour les multiselects dépendant de listes déroulantes, mais pas pour les listes déroulantes dépendantes de multiselects. Le multiselect doit dont être le dernier élément des dépendances 
