### PR TITLE
BACKPORT from 14.0 - option for default checkbox value on new tax form

### DIFF
--- a/htdocs/admin/taxes.php
+++ b/htdocs/admin/taxes.php
@@ -111,6 +111,13 @@ if ($action == 'update') {
 	}
 }
 
+// Set boolean (on/off) constants
+elseif (preg_match('/^(set|del)_?([A-Z_]+)$/', $action, $reg)) {
+	if (!dolibarr_set_const($db, $reg[2], ($reg[1] === 'set' ? '1' : '0'), 'chaine', 0, '', $conf->entity) > 0) {
+		dol_print_error($db);
+	}
+}
+
 
 
 /*
@@ -260,11 +267,26 @@ print "<br>\n";
 
 print '<div class="center">';
 print '<input type="submit" class="button" value="'.$langs->trans("Modify").'" name="button">';
+print '<br/><br/>';
 print '</div>';
 
 print '</form>';
 
+// Options
 
+echo '<div>';
+echo '<table class="noborder centpercent">';
+echo '<thead>';
+echo '<tr class="liste_titre"><th>' . $langs->trans('Parameter') . '</th><th>' . $langs->trans('Value') . '</th></tr>';
+echo '</thead>';
+echo '<tbody>';
+
+$key = 'CREATE_NEW_VAT_WITHOUT_AUTO_PAYMENT';
+echo '<tr><td>', $langs->trans($key), '</td><td>', ajax_constantonoff($key), '</td></tr>';
+
+echo '</tbody>';
+echo '</table>';
+echo '</div>';
 
 
 if (!empty($conf->accounting->enabled))

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -1683,6 +1683,7 @@ YourCompanyDoesNotUseVAT=Your company has been defined to not use VAT (Home - Se
 AccountancyCode=Accounting Code
 AccountancyCodeSell=Sale account. code
 AccountancyCodeBuy=Purchase account. code
+CREATE_NEW_VAT_WITHOUT_AUTO_PAYMENT=By default, leave the checkbox “Automatically create a total payment” empty when creating a new tax object
 ##### Agenda #####
 AgendaSetup=Events and agenda module setup
 PasswordTogetVCalExport=Key to authorize export link

--- a/htdocs/langs/fr_FR/admin.lang
+++ b/htdocs/langs/fr_FR/admin.lang
@@ -1671,6 +1671,7 @@ YourCompanyDoesNotUseVAT=Votre société/institution est définie comme non assu
 AccountancyCode=Code comptable
 AccountancyCodeSell=Code comptable vente
 AccountancyCodeBuy=Code comptable achat
+CREATE_NEW_VAT_WITHOUT_AUTO_PAYMENT=Par défaut, laisser vide l’option « Créer automatiquement un règlement total » sur le formulaire de création d’un nouvel objet TVA
 ##### Agenda #####
 AgendaSetup=Configuration du module actions et agenda
 PasswordTogetVCalExport=Clé pour autoriser le lien d'exportation


### PR DESCRIPTION
# New
cf. https://github.com/Dolibarr/dolibarr/pull/16318

New option to leave the checkbox "Automatically create a total payment" empty by default on the the "new Sales tax" form.