### PR TITLE
Ajout conf qui permet de décocher / cocher par défaut le paiement aut…

### DIFF
--- a/htdocs/langs/en_US/salaries.lang
+++ b/htdocs/langs/en_US/salaries.lang
@@ -2,6 +2,7 @@
 SALARIES_ACCOUNTING_ACCOUNT_PAYMENT=Accounting account used for user third parties
 SALARIES_ACCOUNTING_ACCOUNT_PAYMENT_Desc=The dedicated accounting account defined on user card will be used for Subledger accounting only. This one will be used for General Ledger and as default value of Subledger accounting if dedicated user accounting account on user is not defined.
 SALARIES_ACCOUNTING_ACCOUNT_CHARGE=Accounting account by default for wage payments
+CREATE_NEW_SALARY_WITHOUT_AUTO_PAYMENT=By default, leave empty the option "Automatically create a total payment" when creating a Salary
 Salary=Salary
 Salaries=Salaries
 NewSalaryPayment=New salary card

--- a/htdocs/langs/fr_FR/salaries.lang
+++ b/htdocs/langs/fr_FR/salaries.lang
@@ -2,6 +2,7 @@
 SALARIES_ACCOUNTING_ACCOUNT_PAYMENT=Compte comptable utilisé pour les utilisateurs
 SALARIES_ACCOUNTING_ACCOUNT_PAYMENT_Desc=Le compte comptable défini sur la fiche utilisateur sera utilisé uniquement pour la comptabilité auxiliaire. Celui-ci sera utilisé pour le grand livre et comme valeur par défaut de la comptabilité auxiliaire si le compte dédié de l'utilisateur n'est pas défini.
 SALARIES_ACCOUNTING_ACCOUNT_CHARGE=Compte comptable par défaut pour les paiements de salaires
+CREATE_NEW_SALARY_WITHOUT_AUTO_PAYMENT=Par défaut, laisser vide l’option « Créer automatiquement un règlement total » lors de la création d'un Salaire
 Salary=Salaire
 Salaries=Salaires
 NewSalaryPayment=Nouveau règlement de salaire

--- a/htdocs/salaries/admin/salaries.php
+++ b/htdocs/salaries/admin/salaries.php
@@ -131,6 +131,9 @@ foreach ($list as $key)
 
 print '</tr>';
 
+$key = 'CREATE_NEW_SALARY_WITHOUT_AUTO_PAYMENT';
+echo '<tr><td>', $langs->trans($key), '</td><td>', ajax_constantonoff($key), '</td></tr>';
+
 print "</table>\n";
 
 //dol_fiche_end();
@@ -139,8 +142,6 @@ print '<div class="center"><input type="submit" class="button" value="'.$langs->
 
 print '</form>';
 
-$key = 'CREATE_NEW_SALARY_WITHOUT_AUTO_PAYMENT';
-echo '<tr><td>', $langs->trans($key), '</td><td>', ajax_constantonoff($key), '</td></tr>';
 
 
 // End of page

--- a/htdocs/salaries/admin/salaries.php
+++ b/htdocs/salaries/admin/salaries.php
@@ -69,6 +69,13 @@ if ($action == 'update')
     }
 }
 
+// Set boolean (on/off) constants
+elseif (preg_match('/^(set|del)_?([A-Z_]+)$/', $action, $reg)) {
+	if (!dolibarr_set_const($db, $reg[2], ($reg[1] === 'set' ? '1' : '0'), 'chaine', 0, '', $conf->entity) > 0) {
+		dol_print_error($db);
+	}
+}
+
 /*
  * View
  */
@@ -131,6 +138,10 @@ print "</table>\n";
 print '<div class="center"><input type="submit" class="button" value="'.$langs->trans('Modify').'" name="button"></div>';
 
 print '</form>';
+
+$key = 'CREATE_NEW_SALARY_WITHOUT_AUTO_PAYMENT';
+echo '<tr><td>', $langs->trans($key), '</td><td>', ajax_constantonoff($key), '</td></tr>';
+
 
 // End of page
 llxFooter();

--- a/htdocs/salaries/card.php
+++ b/htdocs/salaries/card.php
@@ -48,7 +48,11 @@ $cancel = GETPOST('cancel', 'aZ09');
 $accountid = GETPOST('accountid', 'int') > 0 ? GETPOST('accountid', 'int') : 0;
 $projectid = (GETPOST('projectid', 'int') ? GETPOST('projectid', 'int') : GETPOST('fk_project', 'int'));
 $confirm = GETPOST('confirm');
-$auto_create_paiement = GETPOST("auto_create_paiement", "int");
+if (GETPOSTISSET('auto_create_paiement') || $action === 'add') {
+	$auto_create_paiement = GETPOST("auto_create_paiement", "int");
+} else {
+	$auto_create_paiement = empty($conf->global->CREATE_NEW_SALARY_WITHOUT_AUTO_PAYMENT);
+}
 
 $datep = dol_mktime(12, 0, 0, GETPOST("datepmonth", 'int'), GETPOST("datepday", 'int'), GETPOST("datepyear", 'int'));
 $datev = dol_mktime(12, 0, 0, GETPOST("datevmonth", 'int'), GETPOST("datevday", 'int'), GETPOST("datevyear", 'int'));
@@ -413,15 +417,10 @@ if ($action == 'create')
 	if (!empty($conf->use_javascript_ajax))
 	{
 		print "\n".'<script type="text/javascript" language="javascript">';
-		print '$(document).ready(function () {
-                $("#radiopayment").click(function() {
-                    $("#label").val($(this).data("label"));
-                });
-                $("#radiorefund").click(function() {
-                    $("#label").val($(this).data("label"));
-                });
-				$("#auto_create_paiement").click(function() {
-					if($(this).is(":checked")) {
+		print /** @lang JavaScript */'
+			$(document).ready(function () {
+				let onAutoCreatePaiementChange = function () {
+					if($("#auto_create_paiement").is(":checked")) {
 						$("#label_fk_account").find("span").addClass("fieldrequired");
 						$("#label_type_payment").find("span").addClass("fieldrequired");
 						$(".hide_if_no_auto_create_payment").show();
@@ -430,21 +429,19 @@ if ($action == 'create')
 						$("#label_type_payment").find("span").removeClass("fieldrequired");
 						$(".hide_if_no_auto_create_payment").hide();
 					}
-				});';
-
-		if ($_REQUEST['action'] === 'add') { // form has been send but there is at least one error
-			if (empty($auto_create_paiement)) {
-				print '$("#label_fk_account").find("span").removeClass("fieldrequired");
-					   $("#label_type_payment").find("span").removeClass("fieldrequired");
-					   $(".hide_if_no_auto_create_payment").hide();';
-			} else {
-				print '$("#label_fk_account").find("span").addClass("fieldrequired");
-					   $("#label_type_payment").find("span").addClass("fieldrequired");
-					   $(".hide_if_no_auto_create_payment").show();';
-			}
-		}
-
-		print '});';
+				};
+				$("#radiopayment").click(function() {
+					$("#label").val($(this).data("label"));
+				});
+				$("#radiorefund").click(function() {
+					$("#label").val($(this).data("label"));
+				});
+				$("#auto_create_paiement").click(function () {
+					onAutoCreatePaiementChange();
+				});
+				onAutoCreatePaiementChange();
+			});
+			';
 		print '</script>'."\n";
 	}
 
@@ -510,7 +507,7 @@ if ($action == 'create')
 
 	// Auto create payment
 	print '<tr><td>'.$langs->trans('AutomaticCreationPayment').'</td>';
-	print '<td><input id="auto_create_paiement" name="auto_create_paiement" type="checkbox" '.($_REQUEST['action'] === 'add' ? (empty($auto_create_paiement) ? '' : 'checked="checked"') : 'checked="checked"').' value="1"></td></tr>'."\n";
+	print '<td><input id="auto_create_paiement" name="auto_create_paiement" type="checkbox" ' . (empty($auto_create_paiement) ? '' : 'checked="checked"') . ' value="1"></td></tr>'."\n";	// Date payment
 
 	// Date payment
 	print '<tr class="hide_if_no_auto_create_payment"><td>';


### PR DESCRIPTION
# New Conf "CREATE_NEW_SALARY_WITHOUT_AUTO_PAYMENT"

Permet de décocher / cocher la création automatique d'un paiement lors de la créationd d'un salaire (comme VAT)

Une fois mergée, à pull la branche NEW/12.0_new_payments_on_salaries dans la 12.0_nysis puis prévenir Gauthier pour qu'il intègre le dev dans la PR standard
