### PR TITLE
T2850 - altering column content of sales journal and accounting ledger

### DIFF
--- a/ChangeLogATM.md
+++ b/ChangeLogATM.md
@@ -1,0 +1,8 @@
+# ChangeLog des ajouts spécifiques client
+
+## 13.0_iseta
+- *14/04/2021* L’affichage des lignes de facture et leur enregistrement dans le grand livre sont modifiés :
+  pour les débits et les crédits, la colonne "Libellé du compte" contient désormais toujours le nom du tiers ;
+  pour les débits, la colonne "Libellé opération" contient désormais uniquement la réf. du service de la ligne de
+  facture correspondante et pour les crédits, la réf. du service précédée du nom du tiers.
+  2b62296b505b64c8c155ecdf65ae13e31de1494a

--- a/htdocs/accountancy/journal/sellsjournal.php
+++ b/htdocs/accountancy/journal/sellsjournal.php
@@ -201,6 +201,7 @@ if ($result) {
 		$tabfac[$obj->rowid]["date"] = $db->jdate($obj->df);
 		$tabfac[$obj->rowid]["datereg"] = $db->jdate($obj->dlr);
 		$tabfac[$obj->rowid]["ref"] = $obj->ref;
+		$tabfac[$obj->rowid]["pref"] = $obj->pref;
 		$tabfac[$obj->rowid]["type"] = $obj->type;
 		$tabfac[$obj->rowid]["description"] = $obj->label_compte;
 		$tabfac[$obj->rowid]["close_code"] = $obj->close_code; // close_code = 'replaced' for replacement invoices (not used in most european countries)
@@ -325,9 +326,15 @@ if ($action == 'writebookkeeping') {
 				$bookkeeping->numero_compte = $conf->global->ACCOUNTING_ACCOUNT_CUSTOMER;
 
 				$accountingaccount->fetch(null, $conf->global->ACCOUNTING_ACCOUNT_CUSTOMER, true);
-				$bookkeeping->label_compte = $accountingaccount->label;
 
-				$bookkeeping->label_operation = dol_trunc($companystatic->name, 16).' - '.$invoicestatic->ref.' - '.$langs->trans("SubledgerAccount");
+				/* ———————————— SPÉ ISETA { ———————————— */
+//				$bookkeeping->label_compte = $accountingaccount->label;
+				$bookkeeping->label_compte = dol_trunc($companystatic->name, 16);
+
+//				$bookkeeping->label_operation = dol_trunc($companystatic->name, 16).' - '.$invoicestatic->ref.' - '.$langs->trans("SubledgerAccount");
+				$bookkeeping->label_operation = $val['pref'];
+				/* ———————————— SPÉ ISETA } ———————————— */
+
 				$bookkeeping->montant = $mt;
 				$bookkeeping->sens = ($mt >= 0) ? 'D' : 'C';
 				$bookkeeping->debit = ($mt >= 0) ? $mt : 0;
@@ -376,8 +383,12 @@ if ($action == 'writebookkeeping') {
 					$bookkeeping->subledger_account = '';
 					$bookkeeping->subledger_label = '';
 					$bookkeeping->numero_compte = $k;
-					$bookkeeping->label_compte = $accountingaccount->label;
-					$bookkeeping->label_operation = dol_trunc($companystatic->name, 16).' - '.$invoicestatic->ref.' - '.$accountingaccount->label;
+					/* ———————————— SPÉ ISETA { ———————————— */
+//					$bookkeeping->label_compte = $accountingaccount->label;
+					$bookkeeping->label_compte = dol_trunc($companystatic->name, 16);
+//					$bookkeeping->label_operation = dol_trunc($companystatic->name, 16).' - '.$invoicestatic->ref.' - '.$accountingaccount->label;
+					$bookkeeping->label_operation = dol_trunc($companystatic->name, 16) . ' ' . $val['pref'];
+					/* ———————————— SPÉ ISETA } ———————————— */
 					$bookkeeping->montant = $mt;
 					$bookkeeping->sens = ($mt < 0) ? 'D' : 'C';
 					$bookkeeping->debit = ($mt < 0) ? -$mt : 0;
@@ -805,13 +816,28 @@ if (empty($action) || $action == 'view') {
 			print '</td>';
 			// Subledger account
 			print "<td>";
-			$accountoshow = length_accounta($k);
-			if (($accountoshow == "") || $accountoshow == 'NotDefined')
-			{
-				print '<span class="error">'.$langs->trans("ThirdpartyAccountNotDefined").'</span>';
-			} else print $accountoshow;
+
+			/* ———————————— SPÉ ISETA { ———————————— */
+			print $companystatic->getNomUrl(0, 'customer', 16);
+//			$accountoshow = length_accounta($k);
+//			if (($accountoshow == "") || $accountoshow == 'NotDefined')
+//			{
+//				print '<span class="error">'.$langs->trans("ThirdpartyAccountNotDefined").'</span>';
+//			} else print $accountoshow;
+			/* ———————————— SPÉ ISETA } ———————————— */
 			print '</td>';
-			print "<td>".$companystatic->getNomUrl(0, 'customer', 16).' - '.$invoicestatic->ref.' - '.$langs->trans("SubledgerAccount")."</td>";
+
+			/* ———————————— SPÉ ISETA { ———————————— */
+			print "<td>"
+//				  .$companystatic->getNomUrl(0, 'customer', 16)
+				  .$val['pref']
+//				  .' - '
+//				  .$invoicestatic->ref
+//				  .' - '
+//				  .$langs->trans("SubledgerAccount")
+				  ."</td>";
+			/* ———————————— SPÉ ISETA } ———————————— */
+
 			print '<td class="right nowraponall">'.($mt >= 0 ? price($mt) : '')."</td>";
 			print '<td class="right nowraponall">'.($mt < 0 ? price(-$mt) : '')."</td>";
 			print "</tr>";
@@ -837,10 +863,25 @@ if (empty($action) || $action == 'view') {
 			print "</td>";
 			// Subledger account
 			print "<td>";
+			/* ———————————— SPÉ ISETA { ———————————— */
+			print $companystatic->getNomUrl(0, 'customer', 16);
+			/* ———————————— SPÉ ISETA } ———————————— */
 			print '</td>';
 			$companystatic->id = $tabcompany[$key]['id'];
 			$companystatic->name = $tabcompany[$key]['name'];
-			print "<td>".$companystatic->getNomUrl(0, 'customer', 16).' - '.$invoicestatic->ref.' - '.$accountingaccount->label."</td>";
+
+
+			/* ———————————— SPÉ ISETA { ———————————— */
+			print "<td>"
+				  .$companystatic->getNomUrl(0, 'customer', 16)
+				  .' '
+				  .$val['pref']
+//				  .' - '
+//				  .$invoicestatic->ref
+//				  .' - '
+//				  .$accountingaccount->label
+				  ."</td>";
+			/* ———————————— SPÉ ISETA } ———————————— */
 			print '<td class="right nowraponall">'.($mt < 0 ? price(-$mt) : '')."</td>";
 			print '<td class="right nowraponall">'.($mt >= 0 ? price($mt) : '')."</td>";
 			print "</tr>";


### PR DESCRIPTION
# NEW
- *14/04/2021* L’affichage des lignes de facture et leur enregistrement dans le grand livre sont modifiés :
  pour les débits et les crédits, la colonne "Libellé du compte" contient désormais toujours le nom du tiers ;
  pour les débits, la colonne "Libellé opération" contient désormais uniquement la réf. du service de la ligne de
  facture correspondante et pour les crédits, la réf. du service précédée du nom du tiers. cf. 
  2b62296b505b64c8c155ecdf65ae13e31de1494a