### PR TITLE
FIX : Add function price2num for rounding values in productAlertStock…

### DIFF
--- a/htdocs/core/boxes/box_produits_alerte_stock.php
+++ b/htdocs/core/boxes/box_produits_alerte_stock.php
@@ -203,7 +203,7 @@ class box_produits_alerte_stock extends ModeleBoxes
 
 					$this->info_box_contents[$line][] = array(
 					    'td' => 'class="center"',
-                        'text' => $objp->total_stock.' / '.$objp->seuil_stock_alerte,
+                        'text' => price2num($objp->total_stock).' / '.$objp->seuil_stock_alerte,
                         'text2'=>img_warning($langs->transnoentitiesnoconv("StockLowerThanLimit", $objp->seuil_stock_alerte)),
                     );
 

--- a/htdocs/core/boxes/box_produits_alerte_stock.php
+++ b/htdocs/core/boxes/box_produits_alerte_stock.php
@@ -203,7 +203,7 @@ class box_produits_alerte_stock extends ModeleBoxes
 
 					$this->info_box_contents[$line][] = array(
 					    'td' => 'class="center"',
-                        'text' => price2num($objp->total_stock).' / '.$objp->seuil_stock_alerte,
+                        'text' => price2num($objp->total_stock, 'MS').' / '.$objp->seuil_stock_alerte,
                         'text2'=>img_warning($langs->transnoentitiesnoconv("StockLowerThanLimit", $objp->seuil_stock_alerte)),
                     );
 


### PR DESCRIPTION
### FIX : Ajout de la fonction price2num() pour arrondir les valeurs de stock présente dans la box "Produit alerte stock"
Les valeurs dans cette box n'étaient pas arrondies, il y avait donc beaucoup de decimales non-désirées
Pour résoudre ce problème :
- Ajout de la fonction price2num()