### PR TITLE
fix MVD 13 liste de bug après test client 

### DIFF
--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -3357,11 +3357,11 @@ abstract class CommonObject
 		$sourcetype = (!empty($sourcetype) ? $sourcetype : $this->element);
 		$targettype = (!empty($targettype) ? $targettype : $this->element);
 
-		/*if (empty($sourceid) && empty($targetid))
+		if (empty($sourceid) && empty($targetid))
 		 {
 		 dol_syslog('Bad usage of function. No source nor target id defined (nor as parameter nor as object id)', LOG_ERR);
 		 return -1;
-		 }*/
+		 }
 
 		// Links between objects are stored in table element_element
 		$sql = 'SELECT rowid, fk_source, sourcetype, fk_target, targettype';

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -4714,10 +4714,13 @@ function vatrate($rate, $addpercent = false, $info_bits = 0, $usestarfornpr = 0)
 	if (preg_match('/%/', $rate))
 	{
 		$rate = str_replace('%', '', $rate);
+
 		$addpercent = true;
 	}
+
 	if (preg_match('/\((.*)\)/', $rate, $reg))
 	{
+
 		$morelabel = ' ('.$reg[1].')';
 		$rate = preg_replace('/\s*'.preg_quote($morelabel, '/').'/', '', $rate);
 	}

--- a/htdocs/product/admin/product.php
+++ b/htdocs/product/admin/product.php
@@ -48,7 +48,6 @@ $value = GETPOST('value', 'alpha');
 $label = GETPOST('label', 'alpha');
 $scandir = GETPOST('scan_dir', 'alpha');
 $type = 'product';
-
 // Pricing Rules
 $select_pricing_rules = array(
 	'PRODUCT_PRICE_UNIQ'=>$langs->trans('PriceCatalogue'), // Unique price
@@ -96,6 +95,7 @@ if ($action == 'other' && GETPOST('value_PRODUIT_MULTIPRICES_LIMIT') > 0)
 	$res = dolibarr_set_const($db, "PRODUIT_MULTIPRICES_LIMIT", GETPOST('value_PRODUIT_MULTIPRICES_LIMIT'), 'chaine', 0, '', $conf->entity);
 	if (!($res > 0)) $error++;
 }
+
 if ($action == 'other')
 {
 	$princingrules = GETPOST('princingrule', 'alpha');

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1888,6 +1888,7 @@ class Product extends CommonObject
 		// If multiprices are enabled, then we check if the current product is subject to price autogeneration
 		// Price will be modified ONLY when the first one is the one that is being modified
 		if ((!empty($conf->global->PRODUIT_MULTIPRICES) || !empty($conf->global->PRODUIT_CUSTOMER_PRICES_BY_QTY_MULTIPRICES)) && !$ignore_autogen && $this->price_autogen && ($level == 1)) {
+
 			return $this->generateMultiprices($user, $newprice, $newpricebase, $newvat, $newnpr, $newpbq);
 		}
 
@@ -2196,6 +2197,8 @@ class Product extends CommonObject
 						$sql .= " AND fk_product = ".$this->id;
 						$sql .= " ORDER BY date_price DESC, rowid DESC";
 						$sql .= " LIMIT 1";
+
+
 						$resql = $this->db->query($sql);
 						if ($resql) {
 							$result = $this->db->fetch_array($resql);

--- a/htdocs/product/dynamic_price/editor.php
+++ b/htdocs/product/dynamic_price/editor.php
@@ -63,7 +63,6 @@ if (empty($eid)) //This also disables fetch when eid == 0
 /*
  * Actions
  */
-
 if ($action == 'add')
 {
 	if ($eid == 0)

--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -1484,7 +1484,7 @@ if ((empty($conf->global->PRODUIT_CUSTOMER_PRICES) || $action == 'showlog_defaul
 			}
 
 			print '<td class="center">'.$langs->trans("PriceBase").'</td>';
-			print $conf->global->PRODUIT_MULTIPRICES_USE_VAT_PER_LEVEL;
+
 			if (empty($conf->global->PRODUIT_MULTIPRICES) && empty($conf->global->PRODUIT_CUSTOMER_PRICES_BY_QTY_MULTIPRICES)) print '<td class="right">'.$langs->trans("DefaultTaxRate").'</td>';
 			print '<td class="right">'.$langs->trans("HT").'</td>';
 			print '<td class="right">'.$langs->trans("TTC").'</td>';

--- a/htdocs/product/price.php
+++ b/htdocs/product/price.php
@@ -1177,13 +1177,14 @@ if ($action == 'edit_vat' && ($user->rights->produit->creer || $user->rights->se
 
 	print '<br></form><br>';
 }
-
 if ($action == 'edit_price' && $object->getRights()->creer)
 {
+
 	print load_fiche_titre($langs->trans("NewPrice"), '');
 
 	if (empty($conf->global->PRODUIT_MULTIPRICES) && empty($conf->global->PRODUIT_CUSTOMER_PRICES_BY_QTY_MULTIPRICES))
 	{
+
 		print '<!-- Edit price -->'."\n";
 		print '<form action="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'" method="POST">';
 		print '<input type="hidden" name="token" value="'.newToken().'">';
@@ -1196,6 +1197,7 @@ if ($action == 'edit_price' && $object->getRights()->creer)
 		print '<table class="border centpercent">';
 
 		// VAT
+
 		print '<tr><td class="titlefield">'.$langs->trans("DefaultTaxRate").'</td><td>';
 		print $form->load_tva("tva_tx", $object->default_vat_code ? $object->tva_tx.' ('.$object->default_vat_code.')' : $object->tva_tx, $mysoc, '', $object->id, $object->tva_npr, $object->type, false, 1);
 		print '</td></tr>';
@@ -1248,6 +1250,7 @@ if ($action == 'edit_price' && $object->getRights()->creer)
 		// Price
 		$product = new Product($db);
 		$product->fetch($id, $ref, '', 1); //Ignore the math expression when getting the price
+
 		print '<tr id="price_numeric"><td>';
 		$text = $langs->trans('SellingPrice');
 		print $form->textwithpicto($text, $langs->trans("PrecisionUnitIsLimitedToXDecimals", $conf->global->MAIN_MAX_DECIMALS_UNIT), 1, 1);
@@ -1292,6 +1295,7 @@ if ($action == 'edit_price' && $object->getRights()->creer)
 
 		print '<br></form>';
 	} else {
+
 		print '<!-- Edit price per level -->'."\n";
 		?>
 		<script>
@@ -1357,6 +1361,8 @@ if ($action == 'edit_price' && $object->getRights()->creer)
 			print '</td>';
 
 			// VAT
+
+			// a la création il ne créer pas les deux autres tva
 			if (empty($conf->global->PRODUIT_MULTIPRICES_USE_VAT_PER_LEVEL)) {
 				print '<td>';
 				print '<input type="hidden" name="tva_tx['.$i.']" value="'.($object->default_vat_code ? $object->tva_tx.' ('.$object->default_vat_code.')' : $object->tva_tx).'">';
@@ -1367,6 +1373,7 @@ if ($action == 'edit_price' && $object->getRights()->creer)
 				print '<input type="hidden" name="localtax2_type['.$i.']" value="'.$object->localtax2_type.'">';
 				print '</td>';
 			} else {
+
 				// This option is kept for backward compatibility but has no sense
 				print '<td style="text-align: center">';
 				print $form->load_tva("tva_tx[".$i.']', $object->multiprices_tva_tx[$i], $mysoc, '', $object->id, false, $object->type, false, 1);
@@ -1414,7 +1421,6 @@ if ($action == 'edit_price' && $object->getRights()->creer)
 	}
 }
 
-
 // List of price changes - log historic (ordered by descending date)
 
 if ((empty($conf->global->PRODUIT_CUSTOMER_PRICES) || $action == 'showlog_default_price') && !in_array($action, array('edit_price', 'edit_vat')))
@@ -1446,6 +1452,7 @@ if ((empty($conf->global->PRODUIT_CUSTOMER_PRICES) || $action == 'showlog_defaul
     		// On l'ajoute donc pour remettre a niveau (pb vieilles versions)
     		// We emulate the change of the price from interface with the same value than the one into table llx_product
             if (!empty($conf->global->PRODUIT_MULTIPRICES)) {
+
             	$object->updatePrice(($object->multiprices_base_type[1] == 'TTC' ? $object->multiprices_ttc[1] : $object->multiprices[1]), $object->multiprices_base_type[1], $user, (empty($object->multiprices_tva_tx[1]) ? 0 : $object->multiprices_tva_tx[1]), ($object->multiprices_base_type[1] == 'TTC' ? $object->multiprices_min_ttc[1] : $object->multiprices_min[1]), 1);
             } else {
             	$object->updatePrice(($object->price_base_type == 'TTC' ? $object->price_ttc : $object->price), $object->price_base_type, $user, $object->tva_tx, ($object->price_base_type == 'TTC' ? $object->price_min_ttc : $object->price_min));

--- a/htdocs/variants/class/ProductCombination.class.php
+++ b/htdocs/variants/class/ProductCombination.class.php
@@ -534,7 +534,7 @@ class ProductCombination
 							$new_price += $variation_price;
 						}
 
-						$child->updatePrice($new_price, $new_type, $user, $new_vat, $new_min_price, $i, $new_npr, $new_psq);
+						$child->updatePrice($new_price, $new_type, $user, $new_vat, $new_min_price, $i, $new_npr, $new_psq,0, array(),$parent->default_vat_code);
 					}
 				}
 			} else {
@@ -809,7 +809,6 @@ class ProductCombination
 				$newcomb->combination_price_levels[$i] = $productCombinationLevel;
 			}
 		}
-		//var_dump($newcomb->combination_price_levels);
 
 		$newproduct->weight += $weight_impact;
 

--- a/htdocs/variants/combinations.php
+++ b/htdocs/variants/combinations.php
@@ -155,7 +155,7 @@ if (($action == 'add' || $action == 'create') && empty($massaction) && !GETPOST(
 
 		// sanit_feature is an array with 1 (and only 1) value per attribute.
 		// For example:  Color->blue, Size->Small, Option->2
-		//var_dump($sanit_features);
+
 		if (!$prodcomb->fetchByProductCombination2ValuePairs($id, $sanit_features))
 		{
 			$result = $prodcomb->createProductCombination($user, $object, $sanit_features, array(), $level_price_impact_percent, $level_price_impact, $weight_impact, $reference);


### PR DESCRIPTION
## FIX : montée de version 9 vers 13 

- TVA par défaut d'un produit est sur 21 alors que devrait être sur 20 (ok sur base copie actuelle, mais pas sur prod) ( fixé avec conf sur la prod )

- Sur un produit enfant (FC1170X1), le taux de TVA est bien sur 20 mais ffiche () au lieu de (TVA20FR)
- Message d'erreur en bas du formulaire de création produit

- Affichage parasite d'un dans l'onglet prix de vente, en dessous de "Historique des prix clients précédents"
