### PR TITLE
Fix price log spam : spé vetcompany à mettre dans le coeur dolibarr

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -1534,7 +1534,40 @@ class Product extends CommonObject
 		}
 	}
 
+	/******* SPE VET COMPANY A METTRE DANS LE COEUR ******/
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	/**
+	 *  check if price have really change to avoid log pollution
+	 *
+	 * @param  int  $level price level to change
+	 * @return int                    <0 if KO, >0 if OK
+	 */
+	private function getArrayForPriceCompare($level = 0)
+	{
+		// phpcs:enable
 
+		$testExit = array('multiprices','multiprices_ttc','multiprices_base_type','multiprices_min','multiprices_min_ttc','multiprices_tva_tx','multiprices_recuperableonly');
+
+		foreach ($testExit as $field){
+			if (!isset($this->$field[$level])) {
+				return array();
+			}
+		}
+
+		$lastPrice = array(
+			'level' => $level ? $level : 1,
+			'multiprices' => doubleval($this->multiprices[$level]),
+			'multiprices_ttc' => doubleval($this->multiprices_ttc[$level]),
+			'multiprices_base_type' => $this->multiprices_base_type[$level],
+			'multiprices_min' => doubleval($this->multiprices_min[$level]),
+			'multiprices_min_ttc' => doubleval($this->multiprices_min_ttc[$level]),
+			'multiprices_tva_tx' => doubleval($this->multiprices_tva_tx[$level]),
+			'multiprices_recuperableonly' => doubleval($this->multiprices_recuperableonly[$level]),
+		);
+
+		return $lastPrice;
+	}
+	/******* END SPE VET COMPANY A METTRE DANS LE COEUR ******/
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
 	/**
@@ -1862,6 +1895,10 @@ class Product extends CommonObject
 	{
 		global $conf, $langs;
 
+		/******* SPE VET COMPANY A METTRE DANS LE COEUR ******/
+		$lastPriceData = $this->getArrayForPriceCompare($level); // temporary store current price before update
+		/******* FIN SPE VET COMPANY A METTRE DANS LE COEUR ******/
+
 		$id = $this->id;
 
 		dol_syslog(get_class($this)."::update_price id=".$id." newprice=".$newprice." newpricebase=".$newpricebase." newminprice=".$newminprice." level=".$level." npr=".$newnpr." newdefaultvatcode=".$newdefaultvatcode);
@@ -1995,7 +2032,12 @@ class Product extends CommonObject
 				// Price by quantity
 				$this->price_by_qty = $newpbq;
 
-				$this->_log_price($user, $level); // Save price for level into table product_price
+				/******* SPE VET COMPANY A METTRE DANS LE COEUR ******/
+				$newPriceData = $this->getArrayForPriceCompare($level);
+				if (!empty(array_diff_assoc($newPriceData, $lastPriceData))) {
+					$this->_log_price($user, $level); // Save price for level into table product_price
+				}
+				/******* FIN SPE VET COMPANY A METTRE DANS LE COEUR ******/
 
 				$this->level = $level; // Store level of price edited for trigger
 


### PR DESCRIPTION
Sur une variante, dès modification des prix depuis le parent, les prix sont dupliqués alors que sur un produit simple non

Ce patch permet de limité le spam sur les log de niveau de prix

j'ai mis des guirlandes au cas ou, car je ne sais pas si Laurent va accepter le fix en 13.0 