### PR TITLE
FIX : Conservation de la Ref client lors du clone d'une facture 

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1180,7 +1180,12 @@ class Facture extends CommonInvoice
 		$object->date_creation      = '';
 		$object->date_modification = '';
 		$object->date_validation    = '';
+
+		/*
+		 * SPE SVD : Keep ref client on invoice cloning
+		 */
 		if (empty($conf->global->MAIN_KEEP_REF_CUSTOMER_ON_CLONING)) $this->ref_client = '';
+
 		$object->close_code         = '';
 		$object->close_note         = '';
 		if ($conf->global->MAIN_DONT_KEEP_NOTE_ON_CLONING == 1) {

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1180,7 +1180,7 @@ class Facture extends CommonInvoice
 		$object->date_creation      = '';
 		$object->date_modification = '';
 		$object->date_validation    = '';
-		$object->ref_client         = '';
+		if (empty($conf->global->MAIN_KEEP_REF_CUSTOMER_ON_CLONING)) $this->ref_client = '';
 		$object->close_code         = '';
 		$object->close_note         = '';
 		if ($conf->global->MAIN_DONT_KEEP_NOTE_ON_CLONING == 1) {


### PR DESCRIPTION
### FIX : Conservation de la Ref client lors du clone d'une facture 

- Utilisation de la conf cachée : MAIN_KEEP_REF_CUSTOMER_ON_CLONING