### PR TITLE
FIX : Bon de prélèvement - DA020854

### DIFF
--- a/htdocs/compta/prelevement/class/bonprelevement.class.php
+++ b/htdocs/compta/prelevement/class/bonprelevement.class.php
@@ -2163,7 +2163,7 @@ class BonPrelevement extends CommonObject
 				$XML_SEPA_INFO .= '					<Cd>SEPA</Cd>'.$CrLf;
 				$XML_SEPA_INFO .= '				</SvcLvl>'.$CrLf;
 				$XML_SEPA_INFO .= '				<LclInstrm>'.$CrLf;
-				$XML_SEPA_INFO .= '					<Cd>CORE</Cd>'.$CrLf;
+				$XML_SEPA_INFO .= '					<Cd>B2B</Cd>'.$CrLf;
 				$XML_SEPA_INFO .= '				</LclInstrm>'.$CrLf;
 				$XML_SEPA_INFO .= '				<SeqTp>'.$format.'</SeqTp>'.$CrLf;
 				$XML_SEPA_INFO .= '			</PmtTpInf>'.$CrLf;


### PR DESCRIPTION
### FIX : Bon de prélèvement

**Les bon de prélèvement étaient rejetés depuis la montée de version de l'intranet en 13** 
C'était du aux bons généré en xml qui ne l'étaient pas correctement : 
- Transformation de la mention "CORE" en "B2B" dans la balise "LclInstrm"
