### PR TITLE
FIX : Ajout de test sur insertion de lignes de facture 

### DIFF
--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4462,7 +4462,17 @@ class FactureLigne extends CommonInvoiceLine
 		$sql.= " '".$this->db->escape($this->localtax1_type)."',";
 		$sql.= " '".$this->db->escape($this->localtax2_type)."',";
 		$sql.= ' '.(! empty($this->fk_product)?$this->fk_product:"null").',';
-		$sql.= " ".$this->product_type.",";
+		
+		/*
+		 * SPE AKTEOS : TK DA020919
+		 * Ne pouvais plus facturer car product_type = null
+		 * Anciennement : $sql.= " ".$this->product_type.",";
+		 */
+		$sql.= ' '.(! empty($this->product_type)?$this->product_type:"null").',';
+		/*
+		 * Fin de SPE AKTEOS
+		 */
+
 		$sql.= " ".price2num($this->remise_percent).",";
 		$sql.= " ".price2num($this->subprice).",";
 		$sql.= ' '.(! empty($this->fk_remise_except)?$this->fk_remise_except:"null").',';

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -4468,7 +4468,7 @@ class FactureLigne extends CommonInvoiceLine
 		 * Ne pouvais plus facturer car product_type = null
 		 * Anciennement : $sql.= " ".$this->product_type.",";
 		 */
-		$sql.= ' '.(! empty($this->product_type)?$this->product_type:"null").',';
+		$sql.= ' '.(! is_null($this->product_type)?$this->product_type:"null").',';
 		/*
 		 * Fin de SPE AKTEOS
 		 */


### PR DESCRIPTION
### FIX : Ajout de test sur insertion de lignes de facture 

Les clients ne pouvaient pas facturer certaines de leurs proposition commerciales car le champ product_type n'était pas rempli à l'insertion de ligne de facture.

- Ajout d'un test mettant null lorsque le product_type n'est pas défini