### PR TITLE
12.0 eurochef product stock

### DIFF
--- a/htdocs/core/lib/product.lib.php
+++ b/htdocs/core/lib/product.lib.php
@@ -119,7 +119,7 @@ function product_prepare_head($object)
 		$h++;
 	}
 
-    if ($object->isProduct() || ($object->isService() && !empty($conf->global->STOCK_SUPPORTS_SERVICES)))    // If physical product we can stock (or service with option)
+    if (($object->isProduct() || ($object->isService() && !empty($conf->global->STOCK_SUPPORTS_SERVICES)) )  && $object->not_managed_in_stock == 0  )    // If physical product we can stock (or service with option)
     {
         if (!empty($conf->stock->enabled) && $user->rights->stock->lire)
         {

--- a/htdocs/core/lib/product.lib.php
+++ b/htdocs/core/lib/product.lib.php
@@ -119,7 +119,7 @@ function product_prepare_head($object)
 		$h++;
 	}
 
-    if (($object->isProduct() || ($object->isService() && !empty($conf->global->STOCK_SUPPORTS_SERVICES)) )  && $object->not_managed_in_stock == 0  )    // If physical product we can stock (or service with option)
+    if (($object->isProduct() || ($object->isService() && !empty($conf->global->STOCK_SUPPORTS_SERVICES)) )  && $object->not_managed_in_stock == Product::ENABLED_STOCK)    // If physical product we can stock (or service with option)
     {
         if (!empty($conf->stock->enabled) && $user->rights->stock->lire)
         {

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1215,7 +1215,6 @@ if ($action == 'create')
 	                    $product_static->status_batch = $line->product_tobatch;
 	                    $text = $product_static->getNomUrl(1);
 	                    $text .= ' - '.(!empty($line->label) ? $line->label : $line->product_label);
-						//$text .= $product->not_managed_in_stock  == Product::DISABLED_STOCK ? ' - '.$langs->trans('stock_disabled') : ' - '.$langs->trans('stock_enabled') ;
 	                    $description = ($conf->global->PRODUIT_DESC_IN_FORM ? '' : dol_htmlentitiesbr($line->desc));
 						$description .= $product->not_managed_in_stock ? $langs->trans('stock_disabled') : $langs->trans('stock_enabled') ;
 						print $form->textwithtooltip($text, $description, 3, '', '', $i);

--- a/htdocs/expedition/card.php
+++ b/htdocs/expedition/card.php
@@ -1176,7 +1176,7 @@ if ($action == 'create')
 	                    $product_static->status_batch = $line->product_tobatch;
 	                    $text = $product_static->getNomUrl(1);
 	                    $text .= ' - '.(!empty($line->label) ? $line->label : $line->product_label);
-						$text .= $product->not_managed_in_stock ? ' - '.$langs->trans('stock_disabled') : ' - '.$langs->trans('stock_enabled') ;
+						$text .= $product->not_managed_in_stock  == Product::DISABLED_STOCK ? ' - '.$langs->trans('stock_disabled') : ' - '.$langs->trans('stock_enabled') ;
 	                    $description = ($conf->global->PRODUIT_DESC_IN_FORM ? '' : dol_htmlentitiesbr($line->desc));
 						$description .= $product->not_managed_in_stock ? $langs->trans('stock_disabled') : $langs->trans('stock_enabled') ;
 						print $form->textwithtooltip($text, $description, 3, '', '', $i);
@@ -1432,7 +1432,7 @@ if ($action == 'create')
 										print '<td class="left">';
 										if ($line->product_type == Product::TYPE_PRODUCT || !empty($conf->global->STOCK_SUPPORTS_SERVICES))
 										{
-											if ($product->not_managed_in_stock == 0){
+											if ($product->not_managed_in_stock == Product::ENABLED_STOCK){
 												print $tmpwarehouseObject->getNomUrl(0).' ';
 												print '<!-- Show details of stock -->';
 												print '('.$stock.')';
@@ -1560,8 +1560,8 @@ if ($action == 'create')
 							    if ($warehouse_selected_id <= 0 ) {
 							    	$disabled = 'disabled="disabled"';
 							    }
-								// finally we overwrite the input with the product status not_managed_in_stock
-								if ( $product->not_managed_in_stock == 1){
+								// finally we overwrite the input with the product status not_managed_in_stock if it's disabled
+								if ( $product->not_managed_in_stock == Product::DISABLED_STOCK){
 									$disabled = '';
 								}
 	    						print '<input name="qtyl'.$indiceAsked.'_'.$subj.'" id="qtyl'.$indiceAsked.'_'.$subj.'" type="text" size="4" value="0"'.($disabled ? ' '.$disabled : '').'> ';
@@ -1584,7 +1584,7 @@ if ($action == 'create')
 	    						else
 	    						{
 	    						    if ($line->fk_product){
-										if ($product->not_managed_in_stock == 0){
+										if ($product->not_managed_in_stock == Product::ENABLED_STOCK){
 
 											print img_warning().' '.$langs->trans("StockTooLow");
 										}else{

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -387,3 +387,4 @@ DeleteLinkedProduct=Delete the child product linked to the combination
 not_managed_in_stock=not managed in stock
 stock_disabled=Stock disabled
 stock_enabled=Stock enabled
+NoWarehouseInBase= No warehouse in database

--- a/htdocs/langs/en_US/products.lang
+++ b/htdocs/langs/en_US/products.lang
@@ -385,4 +385,5 @@ ProductsPricePerCustomer=Product prices per customers
 ProductSupplierExtraFields=Additional Attributes (Supplier Prices)
 DeleteLinkedProduct=Delete the child product linked to the combination
 not_managed_in_stock=not managed in stock
-
+stock_disabled=Stock disabled
+stock_enabled=Stock enabled

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -386,4 +386,5 @@ ProductSupplierExtraFields=Attributs supplémentaires (Prix fournisseur)
 DeleteLinkedProduct=Supprimer le produit enfant lié à la combinaison
 not_managed_in_stock=Désactiver la gestion des stocks
 not_managed_in_stock_description=Si cette option est activée, la modification du stock pour cet élément n'est pas prise en compte. Les mouvements de stock ne seront pas pris en compte dans les commandes client, commande fournisseur, expédition, réception, ordre de fabrication.<br /> Dans les faits, cette option se comporte comme une activation/désactivation du module stock mais à l'échelle du produit/service
-
+stock_disabled=Stock désactivé
+stock_enabled=Stock activé

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -388,3 +388,4 @@ not_managed_in_stock=Désactiver la gestion des stocks
 not_managed_in_stock_description=Si cette option est activée, la modification du stock pour cet élément n'est pas prise en compte. Les mouvements de stock ne seront pas pris en compte dans les commandes client, commande fournisseur, expédition, réception, ordre de fabrication.<br /> Dans les faits, cette option se comporte comme une activation/désactivation du module stock mais à l'échelle du produit/service
 stock_disabled=Stock désactivé
 stock_enabled=Stock activé
+NoWarehouseInBase= Pas d'entrepôt dans la base de données

--- a/htdocs/product/card.php
+++ b/htdocs/product/card.php
@@ -1426,7 +1426,7 @@ else
 
             $type = $langs->trans('Product');
             if ($object->isService()) $type = $langs->trans('Service');
-            //print load_fiche_titre($langs->trans('Modify').' '.$type.' : '.(is_object($object->oldcopy)?$object->oldcopy->ref:$object->ref), "");
+            print load_fiche_titre($langs->trans('Modify').' '.$type.' : '.(is_object($object->oldcopy)?$object->oldcopy->ref:$object->ref), "");
 
             // Main official, simple, and not duplicated code
             print '<form action="'.$_SERVER['PHP_SELF'].'?id='.$object->id.'" method="POST">'."\n";

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -428,6 +428,8 @@ class Product extends CommonObject
     const TYPE_STOCKKIT = 3;
 
 	const NOT_MANAGED_IN_STOCK = 1;
+	const DISABLED_STOCK = 1;
+	const ENABLED_STOCK = 0;
 
     /**
      *  Constructor


### PR DESCRIPTION
# fix 
- rendre possible l'édition input des lignes des produits/services si le stock est désactivé sur le produit
- ajout de l'état du produit (stock activé / désactivé ) dans la ligne descriptif
- affichage de l'état activé/désactivé stock dans la colonne stock lorsque le produit/service est à stock_disable au lieu de l'entrepôt et de la qty dispo
- suppresison de l'onglet stock quand le produit/service a le stock_disable