### PR TITLE
FIX retour réappro

### DIFF
--- a/htdocs/product/stock/replenish.php
+++ b/htdocs/product/stock/replenish.php
@@ -492,6 +492,14 @@ $parameters = array();
 $reshook = $hookmanager->executeHooks('printFieldListWhere', $parameters); // Note that $action and $object may have been modified by hook
 $sql .= $hookmanager->resPrint;
 
+/******************** START SPÉ AMA ***********************/
+// pourquoi ce hook et pas printFieldListWhere?? Parce que printFieldListWhere va être déplacé
+// prochainement et ne conviendra plus pour remplacer l'intégralité de cette requête (ce que fait
+// actuellement [2021-12-09] le hook du cliama)
+$parameters = array('usevirtualstock' => $usevirtualstock, 'alertchecked' => &$alertchecked);
+$reshook = $hookmanager->executeHooks('cliamaReplaceSQL', $parameters, $sql); // Note that $action and $object may have been modified by hook
+/******************** END   SPÉ AMA ***********************/
+
 $nbtotalofrecords = '';
 if (empty($conf->global->MAIN_DISABLE_FULL_SCANLIST)) {
 	$result = $db->query($sql);
@@ -788,6 +796,13 @@ while ($i < ($limit ? min($num, $limit) : $num))
 		$alertstock = $objp->seuil_stock_alerte;
 		$desiredstockwarehouse = ($objp->desiredstockpse ? $objp->desiredstockpse : 0);
 		$alertstockwarehouse = ($objp->seuil_stock_alertepse ? $objp->seuil_stock_alertepse : 0);
+
+		/******************** START SPÉ AMA ***********************/
+		if ($fk_entrepot > 0 || !empty(GETPOST('multiwarehouse'))) {
+			$desiredstock = $desiredstockwarehouse;
+			$alertstock = $alertstockwarehouse;
+		}
+		/******************** END   SPÉ AMA ***********************/
 
 		$warning = '';
 		if ($alertstock && ($stock < $alertstock))


### PR DESCRIPTION
# FIX
- prise en compte du stock désiré / seuil d'alerte par entrepôt
- nouveau hook spécifique AMA pour remplacer printFieldListWhere

# WARNING
Le fix ne fait pas exactement ce qui était demandé → ⚠ valider l'approche fonctionnelle avant de valider la PR 

En gros, le `GROUP BY` fait qu'on a une ligne de produit par entrepôt sélectionné à réapprovisionner, chaque ligne ayant son propre stock optimal / seuil d’alerte, alors que la spécification voudrait qu'on regroupe les ligne par produit uniqument, avec la somme des stocks optimaux / seuils d’alerte ou, si supérieur, le stock optimal / seuil d’alerte renseigné sur le produit lui-même.