### PR TITLE
FIX : TVA 0% on deposit bills

### DIFF
--- a/Changelog-ATM-SPECIFIQUE.md
+++ b/Changelog-ATM-SPECIFIQUE.md
@@ -1,4 +1,6 @@
-
+dolibarr/htdocs/compta/facture/card.php
+    l 1522 => le commit 84f5e3677cf900ff9d268389f2cae84ca0801592 de la 8.0_arcoop
+    n'avait pas été réintroduit lors de la MDV : TVA à 0 sur les factures d'acompte
 
 dolibarr/htdocs/expensereport/card.php  
     Ne PAS afficher le bouton de validation pour les utilisateurs du groupe entrepreneur ID 1  

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1519,7 +1519,10 @@ if (empty($reshook)) {
 											if ($qualified) {
 												$totalamount += $lines[$i]->total_ht; // Fixme : is it not for the customer ? Shouldn't we take total_ttc ?
 												$tva_tx = $lines[$i]->tva_tx;
+												/********************* SPÉ ARCOOP *********************/
+												/*********** TVA à 0 sur factures d'acompte ***********/
 												if(! empty($conf->global->FACTURE_DEPOSITS_ARE_JUST_PAYMENTS)) $tva_tx = 0;
+												/******************* FIN SPÉ ARCOOP *******************/
 												$amountdeposit[$tva_tx] += ($lines[$i]->total_ht * $valuedeposit) / 100;
 											}
 										}

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -1519,6 +1519,7 @@ if (empty($reshook)) {
 											if ($qualified) {
 												$totalamount += $lines[$i]->total_ht; // Fixme : is it not for the customer ? Shouldn't we take total_ttc ?
 												$tva_tx = $lines[$i]->tva_tx;
+												if(! empty($conf->global->FACTURE_DEPOSITS_ARE_JUST_PAYMENTS)) $tva_tx = 0;
 												$amountdeposit[$tva_tx] += ($lines[$i]->total_ht * $valuedeposit) / 100;
 											}
 										}


### PR DESCRIPTION
# FIX

Rappatriement du dev spécifique de la 8.0_arcoop non réintroduit dans la 14.0_arcoop lors de la MDV
=> TVA à 0% sur les factures d'acompte