### PR TITLE
Fix ndf validate keep all files

### DIFF
--- a/Changelog-ATM-SPECIFIQUE.md
+++ b/Changelog-ATM-SPECIFIQUE.md
@@ -34,3 +34,10 @@ dolibarr/htdocs/comm/propal.php
 
 dolibarr/htdocs/core/modules/facture/mod_facture_mercure.php  
     l 133		=> Préfixe devant la numérotation des acomptes (pour gestion prpre des règements)
+
+
+//Suivi depuis le 04/07/2022 après la montée de version 14 ://
+
+dolibarr/htdocs/expensereport/class/expensereport.class.php
+    l 1259 - 1268 - 1269 - 1276 =>  Fix la validation d'une NDF créée depuis une entité
+                                    avec l'entité maître.

--- a/htdocs/expensereport/class/expensereport.class.php
+++ b/htdocs/expensereport/class/expensereport.class.php
@@ -1256,7 +1256,7 @@ class ExpenseReport extends CommonObject
 
 					// Now we rename also files into index
 					$sql = 'UPDATE '.MAIN_DB_PREFIX."ecm_files set filename = CONCAT('".$this->db->escape($this->newref)."', SUBSTR(filename, ".(strlen($this->ref) + 1).")), filepath = 'expensereport/".$this->db->escape($this->newref)."'";
-					$sql .= " WHERE filename LIKE '".$this->db->escape($this->ref)."%' AND filepath = 'expensereport/".$this->db->escape($this->ref)."' and entity = ".$conf->entity;
+					$sql .= " WHERE filename LIKE '".$this->db->escape($this->ref)."%' AND filepath = 'expensereport/".$this->db->escape($this->ref)."' and entity = ".$this->entity;
 					$resql = $this->db->query($sql);
 					if (!$resql) {
 						$error++; $this->error = $this->db->lasterror();
@@ -1265,15 +1265,15 @@ class ExpenseReport extends CommonObject
 					// We rename directory ($this->ref = old ref, $num = new ref) in order not to lose the attachments
 					$oldref = dol_sanitizeFileName($this->ref);
 					$newref = dol_sanitizeFileName($num);
-					$dirsource = $conf->expensereport->dir_output.'/'.$oldref;
-					$dirdest = $conf->expensereport->dir_output.'/'.$newref;
+					$dirsource = $conf->expensereport->multidir_output[$this->entity].'/'.$oldref;
+					$dirdest = $conf->expensereport->multidir_output[$this->entity].'/'.$newref;
 					if (!$error && file_exists($dirsource)) {
 						dol_syslog(get_class($this)."::setValidate() rename dir ".$dirsource." into ".$dirdest);
 
 						if (@rename($dirsource, $dirdest)) {
 							dol_syslog("Rename ok");
 							// Rename docs starting with $oldref with $newref
-							$listoffiles = dol_dir_list($conf->expensereport->dir_output.'/'.$newref, 'files', 1, '^'.preg_quote($oldref, '/'));
+							$listoffiles = dol_dir_list($dirdest, 'files', 1, '^'.preg_quote($oldref, '/'));
 							foreach ($listoffiles as $fileentry) {
 								$dirsource = $fileentry['name'];
 								$dirdest = preg_replace('/^'.preg_quote($oldref, '/').'/', $newref, $dirsource);


### PR DESCRIPTION
Quand l'entité principale valide une NDF créé par une autre entité, le chemin des fichiers joints est bien mis à jour.