### PR TITLE
SPÉ ISETA: FIX export Charlemagne

### DIFF
--- a/ChangelogSpeAtm
+++ b/ChangelogSpeAtm
@@ -1,6 +1,7 @@
 # ChangeLog des ajouts spécifiques client
 
 ## 14.0_iseta
+- FIX : Modification de l'export Charlemagne pour inclure le code analytique et les dates (vides) à la fin - *06/07/2022* - 14.0_iseta
 - *14/04/2021* L’affichage des lignes de facture et leur enregistrement dans le grand livre sont modifiés :
   pour les débits et les crédits, la colonne "Libellé du compte" contient désormais toujours le nom du tiers ;
   pour les débits, la colonne "Libellé opération" contient désormais uniquement la réf. du service de la ligne de


### PR DESCRIPTION
Problème :
Le code analytique est un extrafield de ligne de facture, or ce qu'on exporte, ce sont des lignes de compta, pas de factures.

Ces lignes ne sont pas liées aux lignes de facture (parce qu'il peut y avoir plusieurs lignes de facture pour une même ligne de compta apparemment), mais elles sont liée à la facture.

Du coup, je fais une requête pour récupérer le premier code analytique que je trouverai sur une ligne de la facture, mais c'est potentiellement problématique si plusieurs lignes ont des codes analytiques différents sur la même facture. Je n'ai pas trouvé de solution pour ça car il y a une contradiction entre la spec de l'export et le modèle de données.