### PR TITLE
Export comptable Charlemagne: suppression de colonne vide excédentaire + conversion ISO-8859-1

### DIFF
--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1621,6 +1621,10 @@ class AccountancyExport
 		$separator = "\t";
 		$end_line = "\n";
 
+		/*  ——————————— SPÉ ISETA ——————————— */
+		ob_start();
+		/*  ——————————— FIN SPÉ ISETA ——————— */
+
 		/*
 		 * Charlemagne export need header
 		 */
@@ -1691,6 +1695,12 @@ class AccountancyExport
 			print $separator;                     //Colonne vide
 			print $end_line;
 		}
+
+
+		/*  ——————————— SPÉ ISETA ——————————— */
+		// conversion en ISO-8859-1
+		print mb_convert_encoding(ob_get_clean(), 'ISO-8859-1', 'UTF-8');
+		/*  ——————————— FIN SPÉ ISETA ——————— */
 	}
 
 	/**

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1640,6 +1640,7 @@ class AccountancyExport
 		print self::trunc($langs->transnoentitiesnoconv('AnalyticLabel').' 3', 60).$separator;
 		print self::trunc($langs->transnoentitiesnoconv('SupplierPaymentMethod'), 60).$separator;
 		print self::trunc($langs->transnoentitiesnoconv('SupplierDueDate'), 60).$separator;
+		print $separator;
 		print $end_line;
 
 		foreach ($objectLines as $line) {
@@ -1687,6 +1688,7 @@ class AccountancyExport
 			print $separator;                     //Libellé Analytique 3
 			print $separator;                     //Date
 			print $separator;                     //Date
+			print $separator;                     //Colonne vide
 			print $end_line;
 		}
 	}

--- a/htdocs/accountancy/class/accountancyexport.class.php
+++ b/htdocs/accountancy/class/accountancyexport.class.php
@@ -1643,8 +1643,7 @@ class AccountancyExport
 		print self::trunc($langs->transnoentitiesnoconv('Analytic').' 3', 15).$separator;
 		print self::trunc($langs->transnoentitiesnoconv('AnalyticLabel').' 3', 60).$separator;
 		print self::trunc($langs->transnoentitiesnoconv('SupplierPaymentMethod'), 60).$separator;
-		print self::trunc($langs->transnoentitiesnoconv('SupplierDueDate'), 60).$separator;
-		print $separator;
+		print self::trunc($langs->transnoentitiesnoconv('SupplierDueDate'), 60);
 		print $end_line;
 
 		foreach ($objectLines as $line) {
@@ -1691,8 +1690,6 @@ class AccountancyExport
 			print $separator;                     //Analytique 3
 			print $separator;                     //Libellé Analytique 3
 			print $separator;                     //Date
-			print $separator;                     //Date
-			print $separator;                     //Colonne vide
 			print $end_line;
 		}
 


### PR DESCRIPTION
Entre le fichier « qui marche » fourni par le client (généré par Excel) et notre fichier « qui marche pas », il y a deux différences :

- le fichier généré par Excel a une colonne vide en moins à la fin par rapport à celui généré par Dolibarr
- le fichier généré par excel semble supprimer la partie décimale lorsqu'elle n'est pas discriminante, par ex. `529,00` devient `529`
- il ne semble pas y avoir de différence d'encodage (le fichier Excel est en UTF-8 aussi), confirmé par une comparaison octet par octet → mais d'après le client, même après retravail avec Excel, les caractères spéciaux sont mal importés, donc j'ai ajouté une conversion en ISO-8859-1(encodage probable du logiciel cible même si impossible à savoir vu qu'on n'a aucune spec technique).

Je pense que c'est uniquement la colonne vide qui engendre les problèmes.
