### PR TITLE
FIX : add a fetch after commit before reload

### DIFF
--- a/htdocs/mrp/mo_production.php
+++ b/htdocs/mrp/mo_production.php
@@ -436,11 +436,12 @@ if (empty($reshook)) {
 			$db->rollback();
 		} else {
 			$db->commit();
-
-			// Redirect to avoid to action done a second time if we make a back from browser
+			// Load object
+			include DOL_DOCUMENT_ROOT.'/core/actions_fetchobject.inc.php'; // Must be include, not include_once.
 			header("Location: ".$_SERVER["PHP_SELF"].'?id='.$object->id);
 			exit;
 		}
+
 	}
 
 	// Action close produced


### PR DESCRIPTION
for some still obscure reason I have to fetch the object again to have the visual on the page after redirection
