### PR TITLE
NEW 15.0_atm Update ActionComm type_code on email message ticket

### DIFF
--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1659,13 +1659,13 @@ class Ticket extends CommonObject
 	 * @param array	 $filename_list       List of files to attach (full path of filename on file system)
 	 * @param array	 $mimetype_list       List of MIME type of attached files
 	 * @param array	 $mimefilename_list   List of attached file name in message
+	 * @param boolean	 $send_email      Whether the message is sent by email
 	 * @return int						  <0 if KO, >0 if OK
 	 */
-	public function createTicketMessage($user, $notrigger = 0, $filename_list = array(), $mimetype_list = array(), $mimefilename_list = array())
+	public function createTicketMessage($user, $notrigger = 0, $filename_list = array(), $mimetype_list = array(), $mimefilename_list = array(), $send_email = False)
 	{
 		global $conf, $langs;
 		$error = 0;
-		$send_email = GETPOST('send_email','int');
 
 		$now = dol_now();
 
@@ -1688,7 +1688,7 @@ class Ticket extends CommonObject
 		if ($this->private) {
 			$actioncomm->code = 'TICKET_MSG_PRIVATE';
 		}
-		if ($send_email > 0){
+		if ($send_email){
 			$actioncomm->type_code = 'AC_EMAIL';
 		}
 
@@ -2503,7 +2503,7 @@ class Ticket extends CommonObject
 			$listofnames = $resarray['listofnames'];
 			$listofmimes = $resarray['listofmimes'];
 
-			$id = $object->createTicketMessage($user, 0, $listofpaths, $listofmimes, $listofnames);
+			$id = $object->createTicketMessage($user, 0, $listofpaths, $listofmimes, $listofnames, $send_email);
 			if ($id <= 0) {
 				$error++;
 				$this->error = $object->error;

--- a/htdocs/ticket/class/ticket.class.php
+++ b/htdocs/ticket/class/ticket.class.php
@@ -1665,6 +1665,7 @@ class Ticket extends CommonObject
 	{
 		global $conf, $langs;
 		$error = 0;
+		$send_email = GETPOST('send_email','int');
 
 		$now = dol_now();
 
@@ -1687,6 +1688,10 @@ class Ticket extends CommonObject
 		if ($this->private) {
 			$actioncomm->code = 'TICKET_MSG_PRIVATE';
 		}
+		if ($send_email > 0){
+			$actioncomm->type_code = 'AC_EMAIL';
+		}
+
 		$actioncomm->socid = $this->socid;
 		$actioncomm->label = $this->subject;
 		$actioncomm->note_private = $this->message;


### PR DESCRIPTION
On ticket card "Ajouter un message"
![image](https://user-images.githubusercontent.com/85485123/190155214-ed1e6004-052b-4b69-aacd-76eee3d71a0a.png)

if checkbox to send message by mail

Actioncomm type->code is update

result : 
![image](https://user-images.githubusercontent.com/85485123/190156809-2032a0f7-b7b4-474e-9b3b-0a0296afb82e.png)
