### PR TITLE
FIX paymentmodes.php: rollback on failure to update + remain in edit mode

### DIFF
--- a/htdocs/societe/paymentmodes.php
+++ b/htdocs/societe/paymentmodes.php
@@ -164,9 +164,11 @@ if (empty($reshook))
 			}
 
 			$result = $companybankaccount->update($user);
-			if (! $result)
+			if ($result <= 0)
 			{
+				// Show error message and get back to edit mode
 				setEventMessages($companybankaccount->error, $companybankaccount->errors, 'errors');
+				$action = 'edit';
 			}
 			else
 			{
@@ -481,7 +483,7 @@ if (empty($reshook))
 		$_POST['lang_id'] = GETPOST('lang_idrib'.GETPOST('companybankid', 'int'), 'alpha');
 		$_POST['model'] =  GETPOST('modelrib'.GETPOST('companybankid', 'int'), 'alpha');
 	}
-	
+
 	$id = $socid;
 	$upload_dir = $conf->societe->multidir_output[$object->entity];
 	$permissioncreate=$user->rights->societe->creer;


### PR DESCRIPTION
Actuellement (et c'est aussi le cas en v17), il n'y a pas de transaction sur l'update des IBAN clients (classe CompanyBankAccount), ce qui fait qu'en cas de trigger retournant -1, l'IBAN est quand même sauvegardé.

De plus, si la méthode `update` retourne -1, on ne passe pas dans la gestion d'erreur (la condition est que la valeur de retour soit false).

Cette PR corrige ces 2 points.

## TODO pour aller plus loin

Par contre, sur l'action 'add', il y a bien une transaction mais est sur la fiche et non dans la classe (donc inopérante si jamais on passe par une API ou autre).

De plus, la classe CompanyBankAccount utilise la table `llx_societe_rib` mais hérite de `Account` sans redéfinir son `table_element`, ce qui fait qu'en appelant des méthodes du CommonObject sur un objet CompanyBankAccount, on risque de modifier des comptes bancaires et non des IBAN clients. Il faudrait ajouter ce `table_element`.

cf. #23481 (PR cœur en 15.0), qui est plus complète