### PR TITLE
FIX: translations not loaded in CRON jobs

### DIFF
--- a/htdocs/core/class/translate.class.php
+++ b/htdocs/core/class/translate.class.php
@@ -171,10 +171,11 @@ class Translate
 	 * 	@param	int		$stopafterdirection	Stop when the DIRECTION tag is found (optimize speed)
 	 * 	@param	int		$forcelangdir		To force a different lang directory
 	 *  @param  int     $loadfromfileonly   1=Do not load overwritten translation from file or old conf.
+	 *  @param  int     $forceloadifalreadynotfound   Search translation files again even if a previous attempt was already made on the same domain
 	 *	@return	int							<0 if KO, 0 if already loaded or loading not required, >0 if OK
 	 *  @see loadLangs()
 	 */
-	public function load($domain, $alt = 0, $stopafterdirection = 0, $forcelangdir = '', $loadfromfileonly = 0)
+	public function load($domain, $alt = 0, $stopafterdirection = 0, $forcelangdir = '', $loadfromfileonly = 0, $forceloadifalreadynotfound = 0)
 	{
 		global $conf,$db;
 
@@ -205,7 +206,8 @@ class Translate
 		}
 
         // Check cache
-		if (! empty($this->_tab_loaded[$newdomain]))	// File already loaded for this domain
+		if (! empty($this->_tab_loaded[$newdomain])
+            && ($this->_tab_loaded[$newdomain] != 2 || empty($forceloadifalreadynotfound)))	// File already loaded for this domain
 		{
 			//dol_syslog("Translate::Load already loaded for newdomain=".$newdomain);
 			return 0;

--- a/htdocs/cron/class/cronjob.class.php
+++ b/htdocs/cron/class/cronjob.class.php
@@ -1056,7 +1056,7 @@ class Cronjob extends CommonObject
 			if (! $error)
 			{
 				$result=$langs->load($this->module_name);
-				$result=$langs->load($this->module_name.'@'.$this->module_name);	// If this->module_name was an existing language file, this will make nothing
+				$result=$langs->load($this->module_name.'@'.$this->module_name, 0, 0, '', 0, 1);	// If this->module_name was an existing language file, this will make nothing
 				if ($result < 0)	// If technical error
 				{
 					dol_syslog(get_class($this)."::run_jobs Cannot load module lang file - ".$langs->error, LOG_ERR);
@@ -1128,7 +1128,7 @@ class Cronjob extends CommonObject
 
 			// Load langs
 			$result=$langs->load($this->module_name);
-			$result=$langs->load($this->module_name.'@'.$this->module_name);	// If this->module_name was an existing language file, this will make nothing
+            $result=$langs->load($this->module_name.'@'.$this->module_name, 0, 0, '', 0, 1); // If this->module_name was an existing language file, this will make nothing
 			if ($result < 0)	// If technical error
 			{
 				dol_syslog(get_class($this) . "::run_jobs Cannot load module langs" . $langs->error, LOG_ERR);


### PR DESCRIPTION
This is a backport (the parameter exists in v17)