### PR TITLE
FIX: backport anticipé de PR cœur 29396 pour que l'affichage du stock virtuel se fasse même pour les entrepôts sans stock physique

### DIFF
--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5525,7 +5525,7 @@ class Product extends CommonObject
 		if (! preg_match('/novirtual/', $option)) {
 			// initialize $this->stock_warehouse for all warehouses, even those with no current physical stock because
 			// they may still have a non-zero virtual stock
-			$sql = 'SELECT rowid FROM ' . $this->db->prefix() . 'entrepot WHERE entity IN (' . getEntity('stock') . ')';
+			$sql = "SELECT rowid FROM " . $this->db->prefix() . "entrepot WHERE entity IN (" . getEntity('stock') . ")";
 			$result = $this->db->query($sql);
 			if ($result) {
 				while ($obj = $this->db->fetch_object($result)) {

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -5522,6 +5522,22 @@ class Product extends CommonObject
 			}
 		}
 
+		if (! preg_match('/novirtual/', $option)) {
+			// initialize $this->stock_warehouse for all warehouses, even those with no current physical stock because
+			// they may still have a non-zero virtual stock
+			$sql = 'SELECT rowid FROM ' . $this->db->prefix() . 'entrepot WHERE entity IN (' . getEntity('stock') . ')';
+			$result = $this->db->query($sql);
+			if ($result) {
+				while ($obj = $this->db->fetch_object($result)) {
+					$stockWarehouse = $this->stock_warehouse[$obj->rowid] = new stdClass();
+					$stockWarehouse->id = 0;
+					$stockWarehouse->real = 0;
+					$stockWarehouse->virtual = 0;
+					$stockWarehouse->detail_batch = array();
+				}
+			}
+		}
+
 		$sql = "SELECT ps.rowid, ps.reel, ps.fk_entrepot";
 		$sql .= " FROM ".$this->db->prefix()."product_stock as ps";
 		$sql .= ", ".$this->db->prefix()."entrepot as w";

--- a/htdocs/product/class/product.class.php
+++ b/htdocs/product/class/product.class.php
@@ -3408,7 +3408,7 @@ class Product extends CommonObject
 			while ($obj = $this->db->fetch_object($result)) {
 				/** DEB : BACKPORT STANDARD PR28879**/
 				if ($obj->role == 'toconsume' && empty($warehouseid)) {
-				/** FIN : BACKPORT STANDARD PR28879 **/
+					/** FIN : BACKPORT STANDARD PR28879 **/
 					$this->stats_mrptoconsume['customers'] += $obj->nb_customers;
 					$this->stats_mrptoconsume['nb'] += $obj->nb;
 					$this->stats_mrptoconsume['rows'] += $obj->nb_rows;
@@ -3416,7 +3416,7 @@ class Product extends CommonObject
 				}
 				/** DEB : BACKPORT STANDARD PR28879 **/
 				if ($obj->role == 'consumed' && empty($warehouseid)) {
-				/** FIN : BACKPORT STANDARD PR28879 **/
+					/** FIN : BACKPORT STANDARD PR28879 **/
 					//$this->stats_mrptoconsume['customers'] += $obj->nb_customers;
 					//$this->stats_mrptoconsume['nb'] += $obj->nb;
 					//$this->stats_mrptoconsume['rows'] += $obj->nb_rows;
@@ -5522,6 +5522,7 @@ class Product extends CommonObject
 			}
 		}
 
+		/* BEGIN BACKPORT DOLIBARR : DA024318 [PR](https://github.com/Dolibarr/dolibarr/pull/29396)  */
 		if (! preg_match('/novirtual/', $option)) {
 			// initialize $this->stock_warehouse for all warehouses, even those with no current physical stock because
 			// they may still have a non-zero virtual stock
@@ -5537,6 +5538,8 @@ class Product extends CommonObject
 				}
 			}
 		}
+		/* END BACKPORT DOLIBARR : DA024318 [PR](https://github.com/Dolibarr/dolibarr/pull/29396) */
+
 
 		$sql = "SELECT ps.rowid, ps.reel, ps.fk_entrepot";
 		$sql .= " FROM ".$this->db->prefix()."product_stock as ps";


### PR DESCRIPTION
C'est une PR de backport correspondant à [celle-ci](https://github.com/Dolibarr/dolibarr/pull/29396).

C'est un backport anticipé (la PR cœur n'est pas encore mergée) pour ne pas faire attendre le client. Cependant, il faudra peut-être que je refasse le backport lorsque Laurent aura mergé la PR car j'aurai peut-être des retours à traiter dessus.