### PR TITLE
Add hidden conf to allow or not to classify as billed a supplier orde…

### DIFF
--- a/ChangeLog_edengroupe.md
+++ b/ChangeLog_edengroupe.md
@@ -1,0 +1,1 @@
+- New: Add possibility to classify as billed a supplier order without invoice - **2024/05/13**

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -2517,7 +2517,7 @@ if ($action == 'create') {
 				if (empty($conf->facture->enabled)) {
 					print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=classifybilled">'.$langs->trans("ClassifyBilled").'</a>';
 				} else {
-					if (!empty($object->linkedObjectsIds['invoice_supplier'])) {
+					if (!empty($object->linkedObjectsIds['invoice_supplier']) || (empty($object->linkedObjectsIds['invoice_supplier']) && empty($conf->global->WORKFLOW_DISABLE_CLASSIFY_BILLED_FROM_SUPPLIER_ORDER))) {
 						if ($user->rights->fournisseur->facture->creer || $user->rights->supplier_invoice->creer) {
 							print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=classifybilled">'.$langs->trans("ClassifyBilled").'</a>';
 						}

--- a/htdocs/fourn/commande/card.php
+++ b/htdocs/fourn/commande/card.php
@@ -2517,7 +2517,9 @@ if ($action == 'create') {
 				if (empty($conf->facture->enabled)) {
 					print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=classifybilled">'.$langs->trans("ClassifyBilled").'</a>';
 				} else {
+					// ### Specific Edengroupe
 					if (!empty($object->linkedObjectsIds['invoice_supplier']) || (empty($object->linkedObjectsIds['invoice_supplier']) && empty($conf->global->WORKFLOW_DISABLE_CLASSIFY_BILLED_FROM_SUPPLIER_ORDER))) {
+					// ### Fin Specific Edengroupe
 						if ($user->rights->fournisseur->facture->creer || $user->rights->supplier_invoice->creer) {
 							print '<a class="butAction" href="'.$_SERVER["PHP_SELF"].'?id='.$object->id.'&amp;action=classifybilled">'.$langs->trans("ClassifyBilled").'</a>';
 						}


### PR DESCRIPTION
# NEW [*Hidden conf to allow or not to classify supplier order without invoice as billed*]
Add new conf **WORKFLOW_DISABLE_CLASSIFY_BILLED_FROM_SUPPLIER_ORDER** - set to true to disallow the possibility to classify a supplier order without invoice as billed.
