### PR TITLE
New maintlog recursive dolgetbuttonaction for inline buttons

### DIFF
--- a/ChangeLogMaintlog
+++ b/ChangeLogMaintlog
@@ -1,3 +1,8 @@
+# CHANGELOG 19.0 MAINTLOG FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
+
+* 13/05/24 *
+- NEW : Backport de la [PR Standard](https://github.com/Dolibarr/dolibarr/pull/29629) pour ajouter une conf cachée **MAIN_REMOVE_DROPDOWN_CREATE_BUTTONS_ON_ORDER**, pour afficher l'ancienne version des boutons de création
+
 # CHANGELOG 14.0 MAINTLOG FOR [DOLIBARR ERP CRM](https://www.dolibarr.org)
 
 * 03/01/24 *

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -3018,10 +3018,14 @@ if ($action == 'create' && $usercancreate) {
 				 }
 				 }*/
 
+				$actionButtonsParameters = [
+					"areDropdownButtons"	=> !getDolGlobalInt("MAIN_REMOVE_DROPDOWN_CREATE_BUTTONS_ON_ORDER")
+				];
+
 				if ($numlines > 0) {
-					print dolGetButtonAction('', $langs->trans("Create"), 'default', $arrayforbutaction, $object->id, 1);
+					print dolGetButtonAction('', $langs->trans("Create"), 'default', $arrayforbutaction, $object->id, 1, $actionButtonsParameters);
 				} else {
-					print dolGetButtonAction($langs->trans("ErrorObjectMustHaveLinesToBeValidated", $object->ref), $langs->trans("Create"), 'default', $arrayforbutaction, $object->id, 0);
+					print dolGetButtonAction($langs->trans("ErrorObjectMustHaveLinesToBeValidated", $object->ref), $langs->trans("Create"), 'default', $arrayforbutaction, $object->id, 0, $actionButtonsParameters);
 				}
 
 				// Set to shipped

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -3018,6 +3018,7 @@ if ($action == 'create' && $usercancreate) {
 				 }
 				 }*/
 
+				// ### BACKPORT PR 29629: https://github.com/Dolibarr/dolibarr/pull/29629 ###
 				$actionButtonsParameters = [
 					"areDropdownButtons"	=> !getDolGlobalInt("MAIN_REMOVE_DROPDOWN_CREATE_BUTTONS_ON_ORDER")
 				];
@@ -3027,6 +3028,7 @@ if ($action == 'create' && $usercancreate) {
 				} else {
 					print dolGetButtonAction($langs->trans("ErrorObjectMustHaveLinesToBeValidated", $object->ref), $langs->trans("Create"), 'default', $arrayforbutaction, $object->id, 0, $actionButtonsParameters);
 				}
+				// ### END BACKPORT ###
 
 				// Set to shipped
 				if (($object->statut == Commande::STATUS_VALIDATED || $object->statut == Commande::STATUS_SHIPMENTONPROCESS) && $usercanclose) {

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -11552,9 +11552,27 @@ function dolGetButtonAction($label, $text = '', $actionType = 'default', $url = 
 {
 	global $hookmanager, $action, $object, $langs;
 
-	// If $url is an array, we must build a dropdown button
+	// If $url is an array, we must build a dropdown button or recursively iterate over each value
 	if (is_array($url)) {
 		$out = '';
+
+		if (isset($params["areDropdownButtons"]) && $params["areDropdownButtons"] === false) {
+			foreach ($url as $button) {
+				if (!empty($button['lang'])) {
+					$langs->load($button['lang']);
+				}
+				$label = $langs->trans($button['label']);
+				$text = $button['text'] ?? '';
+				$actionType = $button['actionType'] ?? '';
+				$tmpUrl = DOL_URL_ROOT.$button['url'].(empty($params['backtopage']) ? '' : '&amp;backtopage='.urlencode($params['backtopage']));
+				$id = $button['$id'] ?? '';
+				$userRight = $button['perm'] ?? 1;
+				$params = $button['$params'] ?? [];
+
+				$out .= dolGetButtonAction($label, $text, $actionType, $tmpUrl, $id, $userRight, $params);
+			}
+			return $out;
+		}
 
 		if (count($url) > 1) {
 			$out .= '<div class="dropdown inline-block dropdown-holder">';

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -11556,6 +11556,7 @@ function dolGetButtonAction($label, $text = '', $actionType = 'default', $url = 
 	if (is_array($url)) {
 		$out = '';
 
+		// ### BACKPORT PR 29629: https://github.com/Dolibarr/dolibarr/pull/29629 ###
 		if (isset($params["areDropdownButtons"]) && $params["areDropdownButtons"] === false) {
 			foreach ($url as $button) {
 				if (!empty($button['lang'])) {
@@ -11573,6 +11574,7 @@ function dolGetButtonAction($label, $text = '', $actionType = 'default', $url = 
 			}
 			return $out;
 		}
+		// ### END BACKPORT ###
 
 		if (count($url) > 1) {
 			$out .= '<div class="dropdown inline-block dropdown-holder">';


### PR DESCRIPTION
# New - backport de la [PR Standard](https://github.com/Dolibarr/dolibarr/pull/29629) pour affichage de l'ancienne version des boutons de création
- Backport de la [PR Standard](https://github.com/Dolibarr/dolibarr/pull/29629) pour ajouter une conf cachée **MAIN_REMOVE_DROPDOWN_CREATE_BUTTONS_ON_ORDER**, pour afficher l'ancienne version des boutons de création

