### PR TITLE
DA025251

### DIFF
--- a/htdocs/core/class/commoninvoice.class.php
+++ b/htdocs/core/class/commoninvoice.class.php
@@ -240,7 +240,7 @@ abstract class CommonInvoice extends CommonObject
 	 *	@return		float|int|array						Amount of payment already done, <0 and set ->error if KO
 	 *  @see getSumDepositsUsed(), getSumCreditNotesUsed()
 	 */
-	public function getSommePaiement($multicurrency = 0)
+	public function getSommePaiement($multicurrency = 0, &$nb = 0)
 	{
 		$table = 'paiement_facture';
 		$field = 'fk_facture';
@@ -249,7 +249,7 @@ abstract class CommonInvoice extends CommonObject
 			$field = 'fk_facturefourn';
 		}
 
-		$sql = "SELECT sum(amount) as amount, sum(multicurrency_amount) as multicurrency_amount";
+		$sql = "SELECT count(rowid) nb, sum(amount) as amount, sum(multicurrency_amount) as multicurrency_amount";
 		$sql .= " FROM ".$this->db->prefix().$table;
 		$sql .= " WHERE ".$field." = ".((int) $this->id);
 
@@ -258,7 +258,7 @@ abstract class CommonInvoice extends CommonObject
 		$resql = $this->db->query($sql);
 		if ($resql) {
 			$obj = $this->db->fetch_object($resql);
-
+			$nb = $obj->nb;
 			$this->db->free($resql);
 
 			if ($obj) {

--- a/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
@@ -257,8 +257,7 @@ class pdf_crabe extends ModelePDFFactures
 
 		if ($conf->facture->dir_output) {
 			$object->fetch_thirdparty();
-
-			$deja_regle = $object->getSommePaiement((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0);
+			$deja_regle = $object->getSommePaiement((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0, $hasPaiements);
 			$amount_credit_notes_included = $object->getSumCreditNotesUsed((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0);
 			$amount_deposits_included = $object->getSumDepositsUsed((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0);
 
@@ -849,7 +848,7 @@ class pdf_crabe extends ModelePDFFactures
 				$posy = $this->_tableau_tot($pdf, $object, $deja_regle, $bottomlasttab, $outputlangs, $outputlangsbis);
 
 				// Display Payments area
-				if (($deja_regle || $amount_credit_notes_included || $amount_deposits_included) && !getDolGlobalString('INVOICE_NO_PAYMENT_DETAILS')) {
+				if (($hasPaiements || $deja_regle || $amount_credit_notes_included || $amount_deposits_included) && !getDolGlobalString('INVOICE_NO_PAYMENT_DETAILS')) {
 					$posy = $this->_tableau_versements($pdf, $object, $posy, $outputlangs, $heightforfooter);
 				}
 

--- a/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_crabe.modules.php
@@ -257,6 +257,7 @@ class pdf_crabe extends ModelePDFFactures
 
 		if ($conf->facture->dir_output) {
 			$object->fetch_thirdparty();
+			$hasPaiements = 0;
 			$deja_regle = $object->getSommePaiement((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0, $hasPaiements);
 			$amount_credit_notes_included = $object->getSumCreditNotesUsed((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0);
 			$amount_deposits_included = $object->getSumDepositsUsed((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0);

--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -290,7 +290,7 @@ class pdf_sponge extends ModelePDFFactures
 		if ($conf->facture->multidir_output[$conf->entity]) {
 			$object->fetch_thirdparty();
 
-			$deja_regle = $object->getSommePaiement((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0);
+			$deja_regle = $object->getSommePaiement((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0, $hasPaiements);
 			$amount_credit_notes_included = $object->getSumCreditNotesUsed((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0);
 			$amount_deposits_included = $object->getSumDepositsUsed((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0);
 
@@ -1005,7 +1005,7 @@ class pdf_sponge extends ModelePDFFactures
 				$posy = $this->drawTotalTable($pdf, $object, $deja_regle, $bottomlasttab, $outputlangs, $outputlangsbis);
 
 				// Display payment area
-				if (($deja_regle || $amount_credit_notes_included || $amount_deposits_included) && !getDolGlobalString('INVOICE_NO_PAYMENT_DETAILS')) {
+				if (($hasPaiements || $deja_regle || $amount_credit_notes_included || $amount_deposits_included) && !getDolGlobalString('INVOICE_NO_PAYMENT_DETAILS')) {
 					$posy = $this->drawPaymentsTable($pdf, $object, $posy, $outputlangs);
 				}
 

--- a/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
+++ b/htdocs/core/modules/facture/doc/pdf_sponge.modules.php
@@ -289,7 +289,7 @@ class pdf_sponge extends ModelePDFFactures
 
 		if ($conf->facture->multidir_output[$conf->entity]) {
 			$object->fetch_thirdparty();
-
+			$hasPaiements = 0;
 			$deja_regle = $object->getSommePaiement((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0, $hasPaiements);
 			$amount_credit_notes_included = $object->getSumCreditNotesUsed((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0);
 			$amount_deposits_included = $object->getSumDepositsUsed((isModEnabled("multicurrency") && $object->multicurrency_tx != 1) ? 1 : 0);


### PR DESCRIPTION
# FIX|Fix #[*issue_number Short description*]
[*Long description*]
Non affichage du tableau de paiement sur les pdf facture

Quand on a des lignes de type prélévements négative et positive
Et que le somme des lignes est égal a 0

Avant l'affichage était conditionné par le fait que la somme des lignes de paiement était positive, maintenant on prend aussi en compte le fait qu'il existe bien des lignes pour les afficher sur la PDF.