### PR TITLE
FIX :  DA025365 clear session extrafleds if mendatory and empty

### DIFF
--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -415,12 +415,12 @@ if (empty($reshook) && $action == 'add') {
 		$object->contact_id = key($object->socpeopleassigned);
 	}
 
-	// Fill array 'array_options' with data from add form
+// Fill array 'array_options' with data from add form
 	$ret = $extrafields->setOptionalsFromPost(null, $object);
 	if ($ret < 0) {
-		$error++;
+		$error++; $donotclearsession = 1;
+		$action = 'create';
 	}
-
 
 
 	if (!$error) {

--- a/htdocs/comm/action/card.php
+++ b/htdocs/comm/action/card.php
@@ -418,7 +418,8 @@ if (empty($reshook) && $action == 'add') {
 // Fill array 'array_options' with data from add form
 	$ret = $extrafields->setOptionalsFromPost(null, $object);
 	if ($ret < 0) {
-		$error++; $donotclearsession = 1;
+		$error++; 
+		$donotclearsession = 1;
 		$action = 'create';
 	}
 


### PR DESCRIPTION
fix clearsession extrafleds if mendatory and empty when an extrafields is mandatory and not specified