### PR TITLE
Backport commit e19a60cd6237355fe1f8cbaf7039c6678002ac8f from V20 to …

### DIFF
--- a/htdocs/fourn/class/fournisseur.facture.class.php
+++ b/htdocs/fourn/class/fournisseur.facture.class.php
@@ -2881,7 +2881,9 @@ class FactureFournisseur extends CommonInvoice
 			$dir = dol_buildpath($reldir."core/modules/supplier_invoice/");
 
 			// Load file with numbering class (if found)
-			$mybool |= @include_once $dir.$file;
+			// BACKPORT V20 from e19a60cd6237355fe1f8cbaf7039c6678002ac8f
+			$mybool = ((bool) @include_once $dir.$file) || $mybool;
+			// END BACKPORT
 		}
 
 		if ($mybool === false) {


### PR DESCRIPTION
# FIX

- Error of including not found file in supplier invoice - backporting [commit from V20](https://github.com/Dolibarr/dolibarr/commit/e19a60cd6237355fe1f8cbaf7039c6678002ac8f)