### PR TITLE
REPORT STANDARD FIX: BIC requirement is now checked separately from IBAN

### DIFF
--- a/htdocs/compta/bank/class/account.class.php
+++ b/htdocs/compta/bank/class/account.class.php
@@ -1568,8 +1568,9 @@ class Account extends CommonObject
 		return 0;
 	}
 
+
 	/**
-	 * Return 1 if IBAN / BIC is mandatory (otherwise option)
+	 * Return 1 if IBAN is mandatory (otherwise option) // REPORT STANDARD
 	 *
 	 * @return		int        1 = mandatory / 0 = Not mandatory
 	 */
@@ -1621,6 +1622,38 @@ class Account extends CommonObject
 
 		if (in_array($country_code, $country_code_in_EEC)) {
 			return 1; // France, Spain, ...
+		}
+		return 0;
+	}
+
+// REPORT STANDARD
+	/**
+	 * Return 1 if BIC is mandatory (otherwise option)
+	 *
+	 * @return		int        1 = mandatory / 0 = Not mandatory
+	 */
+	public function needBIC()
+	{
+		if (getDolGlobalString('MAIN_IBAN_IS_NEVER_MANDATORY')) {
+			return 0;
+		}
+
+		$country_code = $this->getCountryCode();
+
+		$country_code_in_EEC = array(
+			'AD', // Andorra
+			'BH', // Bahrein
+			'DK', // Denmark
+			'FR', // France
+			'GH', // Ghana
+			'HU', // Hungary
+			'JP', // Japan
+			'LV', // Latvia
+			'SE', // Sweden
+		);
+
+		if (in_array($country_code, $country_code_in_EEC)) {
+			return 1; // Andorra, Bahrein, ...
 		}
 		return 0;
 	}

--- a/htdocs/societe/paymentmodes.php
+++ b/htdocs/societe/paymentmodes.php
@@ -150,6 +150,8 @@ if (empty($reshook)) {
 				$action = 'edit';
 				$error++;
 			}
+		} // REPORT STANDARD
+		if ($companybankaccount->needBIC() == 1) {// REPORT STANDARD
 			if (!GETPOST('bic')) {
 				setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("BIC")), null, 'errors');
 				$action = 'edit';
@@ -306,6 +308,8 @@ if (empty($reshook)) {
 					$action = 'create';
 					$error++;
 				}
+			} // REPORT STANDARD
+			if ($companybankaccount->needBIC() == 1) { // REPORT STANDARD
 				if (!GETPOST('bic')) {
 					setEventMessages($langs->trans("ErrorFieldRequired", $langs->transnoentitiesnoconv("BIC")), null, 'errors');
 					$action = 'create';
@@ -1850,7 +1854,7 @@ if ($socid && $action == 'edit' && $permissiontoaddupdatepaymentinformation) {
 			$name = 'bic';
 			$size = 12;
 			$content = $companybankaccount->bic;
-			if ($companybankaccount->needIBAN()) {
+			if ($companybankaccount->needBIC()) { // REPORT STANDARD
 				$require = true;
 			}
 			$tooltip = $langs->trans("Example").': LIABLT2XXXX';
@@ -2021,7 +2025,7 @@ if ($socid && $action == 'create' && $permissiontoaddupdatepaymentinformation) {
 			$name = 'bic';
 			$size = 12;
 			$content = $companybankaccount->bic;
-			if ($companybankaccount->needIBAN()) {
+			if ($companybankaccount->needBIC()) { // REPORT STANDARD
 				$require = true;
 			}
 			$tooltip = $langs->trans("Example").': LIABLT2XXXX';


### PR DESCRIPTION
REPORT STANDARD

# FIX|BIC requirement is now checked separately from IBAN

Currently, the same function is used top check is an IBAN is required and if a BIC is required:
![image](https://github.com/user-attachments/assets/0db1a31f-cbff-4574-986b-7b119f1d1f7f)

The needIBAN() function checks if the country is among a list of countries to decide if the field IBAN can be left blank or not.

I've added a needBIC() function which works the same way but for BIC/SWIFT since the list of countries where the BIC is mandatory is different than for IBAN (ex: Belgium requires an IBAN but not a BIC)
I've based the list on these sources:
https://www.westernunion.com/fr/fr/swift-bic-codes.html
https://qonto.com/fr/swift-codes
![image](https://github.com/user-attachments/assets/2cfc2c62-4c5f-42d9-9e4f-ad7b423247b2)
![image](https://github.com/user-attachments/assets/9350008e-5109-48c3-a370-aeb89f196aaa)

HOWEVER: I still added France to the list so in order to change as little as possible the way it has been working in dolibarr, even if technically BIC isn't mandatory in France.
![image](https://github.com/user-attachments/assets/e48e3876-2226-49d6-b7a4-52188ef5f81f)
