### PR TITLE
Backport de la PR #31463

### DIFF
--- a/ChangeLog_Koesio.md
+++ b/ChangeLog_Koesio.md
@@ -1,2 +1,4 @@
 ## Backported from 17.0 :
+- Backport  21.0 PR #31463 : Tab to see generated invoices on recurring 
+  supplier or customer invoice cards - *2024-10-23*
 - Backport  17.0 PR #31445 : Follow ExtraFields between model invoice and classic invoice - *2024-10-18*

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -140,7 +140,7 @@ $search_datelimit_end = dol_mktime(23, 59, 59, $search_datelimit_endmonth, $sear
 $search_categ_cus = GETPOST("search_categ_cus", 'int');
 $search_product_category = GETPOST('search_product_category', 'int');
 $search_fac_rec_source_title = GETPOST("search_fac_rec_source_title", 'alpha');
-$search_fk_fac_rec_source = GETPOST('search_fk_fac_rec_source', 'int');
+$search_fk_fac_rec_source = GETPOST('search_fk_fac_rec_source', 'int'); // backport 21.0 #31463
 $search_btn = GETPOST('button_search', 'alpha');
 $search_remove_btn = GETPOST('button_removefilter', 'alpha');
 
@@ -819,6 +819,7 @@ if ($search_user > 0) {
 if (!empty($search_fac_rec_source_title)) {
 	$sql .= natural_search('facrec.titre', $search_fac_rec_source_title);
 }
+// backport 21.0 #31463
 if ($search_fk_fac_rec_source) {
 	$sql .= ' AND f.fk_fac_rec_source = ' . (int) $search_fk_fac_rec_source;
 }
@@ -983,6 +984,7 @@ if ($resql) {
 		}
 	}
 
+	// backport 21.0 #31463
 	if ($search_fk_fac_rec_source) {
 		$object = new FactureRec($db);
 	$object->id = (int) $search_fk_fac_rec_source;
@@ -1162,6 +1164,7 @@ if ($resql) {
 	if (!empty($search_fac_rec_source_title)) {
 		$param .= '&search_fac_rec_source_title='.urlencode($search_fac_rec_source_title);
 	}
+// backport 21.0 #31463
 if ($search_fk_fac_rec_source) {
 	$param .= '&search_fk_fac_rec_source=' . (int) $search_fk_fac_rec_source;
 }

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -985,7 +985,7 @@ if ($resql) {
 
 	if ($search_fk_fac_rec_source) {
 		$object = new FactureRec($db);
-		$object->id = $search_fk_fac_rec_source;
+	$object->id = (int) $search_fk_fac_rec_source;
 		$head = invoice_rec_prepare_head($object);
 		print dol_get_fiche_head($head, 'generated', $langs->trans('InvoicesGeneratedFromRec'), -1, 'bill'); // Add a div
 	}

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -140,6 +140,7 @@ $search_datelimit_end = dol_mktime(23, 59, 59, $search_datelimit_endmonth, $sear
 $search_categ_cus = GETPOST("search_categ_cus", 'int');
 $search_product_category = GETPOST('search_product_category', 'int');
 $search_fac_rec_source_title = GETPOST("search_fac_rec_source_title", 'alpha');
+$search_fk_fac_rec_source = GETPOST('search_fk_fac_rec_source', 'int');
 $search_btn = GETPOST('button_search', 'alpha');
 $search_remove_btn = GETPOST('button_removefilter', 'alpha');
 
@@ -818,6 +819,9 @@ if ($search_user > 0) {
 if (!empty($search_fac_rec_source_title)) {
 	$sql .= natural_search('facrec.titre', $search_fac_rec_source_title);
 }
+if ($search_fk_fac_rec_source) {
+	$sql .= ' AND f.fk_fac_rec_source = ' . (int) $search_fk_fac_rec_source;
+}
 // Search for tag/category ($searchCategoryProductList is an array of ID)
 $searchCategoryProductList = $search_product_category ? array($search_product_category) : array();
 $searchCategoryProductOperator = 0;
@@ -977,6 +981,13 @@ if ($resql) {
 		if (empty($search_company)) {
 			$search_company = $soc->name;
 		}
+	}
+
+	if ($search_fk_fac_rec_source) {
+		$object = new FactureRec($db);
+		$object->id = $search_fk_fac_rec_source;
+		$head = invoice_rec_prepare_head($object);
+		print dol_get_fiche_head($head, 'generated', $langs->trans('InvoicesGeneratedFromRec'), -1, 'bill'); // Add a div
 	}
 
 	$param = '&socid='.urlencode($socid);

--- a/htdocs/compta/facture/list.php
+++ b/htdocs/compta/facture/list.php
@@ -1162,6 +1162,9 @@ if ($resql) {
 	if (!empty($search_fac_rec_source_title)) {
 		$param .= '&search_fac_rec_source_title='.urlencode($search_fac_rec_source_title);
 	}
+if ($search_fk_fac_rec_source) {
+	$param .= '&search_fk_fac_rec_source=' . (int) $search_fk_fac_rec_source;
+}
 
 	// Add $param from extra fields
 	include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_param.tpl.php';

--- a/htdocs/core/lib/invoice.lib.php
+++ b/htdocs/core/lib/invoice.lib.php
@@ -250,7 +250,7 @@ function invoice_rec_prepare_head($object)
 /**
  * Return array head with list of tabs to view object informations.
  *
- * @param   Facture     $object     Invoice object
+ * @param   FactureFournisseurRec     $object     Invoice object
  * @return array                    head array with tabs
  */
 function supplier_invoice_rec_prepare_head($object)

--- a/htdocs/core/lib/invoice.lib.php
+++ b/htdocs/core/lib/invoice.lib.php
@@ -231,6 +231,11 @@ function invoice_rec_prepare_head($object)
 	$head[$h][2] = 'card';
 	$h++;
 
+	$head[$h][0] = DOL_URL_ROOT . '/compta/facture/list.php?search_fk_fac_rec_source=' . $object->id;
+	$head[$h][1] = $langs->trans('InvoicesGeneratedFromRec');
+	$head[$h][2] = 'generated';
+	$h++;
+
 	// Show more tabs from modules
 	// Entries must be declared in modules descriptor with line
 	// $this->tabs = array('entity:+tabname:Title:@mymodule:/mymodule/mypage.php?id=__ID__');   to add new tab
@@ -258,6 +263,11 @@ function supplier_invoice_rec_prepare_head($object)
 	$head[$h][0] = DOL_URL_ROOT . '/fourn/facture/card-rec.php?id=' . $object->id;
 	$head[$h][1] = $langs->trans("RepeatableSupplierInvoice");
 	$head[$h][2] = 'card';
+	$h++;
+
+	$head[$h][0] = DOL_URL_ROOT . '/fourn/facture/list.php?search_fk_fac_rec_source=' . $object->id;
+	$head[$h][1] = $langs->trans('InvoicesGeneratedFromRec');
+	$head[$h][2] = 'generated';
 	$h++;
 
 	// Show more tabs from modules

--- a/htdocs/core/lib/invoice.lib.php
+++ b/htdocs/core/lib/invoice.lib.php
@@ -231,6 +231,7 @@ function invoice_rec_prepare_head($object)
 	$head[$h][2] = 'card';
 	$h++;
 
+	// backport 21.0 #31463
 	$head[$h][0] = DOL_URL_ROOT . '/compta/facture/list.php?search_fk_fac_rec_source=' . $object->id;
 	$head[$h][1] = $langs->trans('InvoicesGeneratedFromRec');
 	$head[$h][2] = 'generated';
@@ -265,6 +266,7 @@ function supplier_invoice_rec_prepare_head($object)
 	$head[$h][2] = 'card';
 	$h++;
 
+	// backport 21.0 #31463
 	$head[$h][0] = DOL_URL_ROOT . '/fourn/facture/list.php?search_fk_fac_rec_source=' . $object->id;
 	$head[$h][1] = $langs->trans('InvoicesGeneratedFromRec');
 	$head[$h][2] = 'generated';

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -119,7 +119,7 @@ $search_btn = GETPOST('button_search', 'alpha');
 $search_remove_btn = GETPOST('button_removefilter', 'alpha');
 $search_categ_sup = trim(GETPOST("search_categ_sup", 'int'));
 $search_product_category = GETPOST('search_product_category', 'int');
-$search_fk_fac_rec_source = GETPOST('search_fk_fac_rec_source', 'int');
+$search_fk_fac_rec_source = GETPOST('search_fk_fac_rec_source', 'int'); // backport 21.0 #31463
 
 $option = GETPOST('search_option');
 if ($option == 'late') {
@@ -595,6 +595,7 @@ if ($option == 'late') {
 if ($search_label) {
 	$sql .= natural_search('f.libelle', $search_label);
 }
+// backport 21.0 #31463
 if ($search_fk_fac_rec_source) {
 	$sql .= " AND f.fk_fac_rec_source = ".(int) $search_fk_fac_rec_source;
 }
@@ -760,6 +761,7 @@ if ($num == 1 && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $
 
 llxHeader('', $langs->trans("SuppliersInvoices"), 'EN:Suppliers_Invoices|FR:FactureFournisseur|ES:Facturas_de_proveedores');
 
+// backport 21.0 #31463
 if ($search_fk_fac_rec_source) {
 	require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.facture-rec.class.php';
 	require_once DOL_DOCUMENT_ROOT . '/core/lib/invoice.lib.php';
@@ -905,6 +907,7 @@ if ($search_categ_sup > 0) {
 if ($search_type_thirdparty != '' && $search_type_thirdparty > 0) {
 	$param .= '&search_type_thirdparty='.urlencode($search_type_thirdparty);
 }
+// backport 21.0 #31463
 if ($search_fk_fac_rec_source) {
 	$param .= '&search_fk_fac_rec_source=' . (int) $search_fk_fac_rec_source;
 }

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -119,6 +119,7 @@ $search_btn = GETPOST('button_search', 'alpha');
 $search_remove_btn = GETPOST('button_removefilter', 'alpha');
 $search_categ_sup = trim(GETPOST("search_categ_sup", 'int'));
 $search_product_category = GETPOST('search_product_category', 'int');
+$search_fk_fac_rec_source = GETPOST('search_fk_fac_rec_source', 'int');
 
 $option = GETPOST('search_option');
 if ($option == 'late') {
@@ -594,6 +595,9 @@ if ($option == 'late') {
 if ($search_label) {
 	$sql .= natural_search('f.libelle', $search_label);
 }
+if ($search_fk_fac_rec_source) {
+	$sql .= " AND f.fk_fac_rec_source = ".(int) $search_fk_fac_rec_source;
+}
 $searchCategorySupplierList = $search_categ_sup ? array($search_categ_sup) : array();
 $searchCategorySupplierOperator = 0;
 // Search for tag/category ($searchCategorySupplierList is an array of ID)
@@ -755,6 +759,15 @@ if ($num == 1 && !empty($conf->global->MAIN_SEARCH_DIRECT_OPEN_IF_ONLY_ONE) && $
 }
 
 llxHeader('', $langs->trans("SuppliersInvoices"), 'EN:Suppliers_Invoices|FR:FactureFournisseur|ES:Facturas_de_proveedores');
+
+if ($search_fk_fac_rec_source) {
+	require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.facture-rec.class.php';
+	require_once DOL_DOCUMENT_ROOT . '/core/lib/invoice.lib.php';
+	$object = new FactureFournisseurRec($db);
+	$object->id = $search_fk_fac_rec_source;
+	$head = supplier_invoice_rec_prepare_head($object);
+	print dol_get_fiche_head($head, 'generated', $langs->trans('InvoicesGeneratedFromRec'), -1, 'bill'); // Add a div
+}
 
 if ($socid) {
 	$soc = new Societe($db);

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -905,6 +905,9 @@ if ($search_categ_sup > 0) {
 if ($search_type_thirdparty != '' && $search_type_thirdparty > 0) {
 	$param .= '&search_type_thirdparty='.urlencode($search_type_thirdparty);
 }
+if ($search_fk_fac_rec_source) {
+	$param .= '&search_fk_fac_rec_source=' . (int) $search_fk_fac_rec_source;
+}
 
 // Add $param from extra fields
 include DOL_DOCUMENT_ROOT.'/core/tpl/extrafields_list_search_param.tpl.php';

--- a/htdocs/fourn/facture/list.php
+++ b/htdocs/fourn/facture/list.php
@@ -764,7 +764,7 @@ if ($search_fk_fac_rec_source) {
 	require_once DOL_DOCUMENT_ROOT . '/fourn/class/fournisseur.facture-rec.class.php';
 	require_once DOL_DOCUMENT_ROOT . '/core/lib/invoice.lib.php';
 	$object = new FactureFournisseurRec($db);
-	$object->id = $search_fk_fac_rec_source;
+	$object->id = (int) $search_fk_fac_rec_source;
 	$head = supplier_invoice_rec_prepare_head($object);
 	print dol_get_fiche_head($head, 'generated', $langs->trans('InvoicesGeneratedFromRec'), -1, 'bill'); // Add a div
 }

--- a/htdocs/langs/en_US/bills.lang
+++ b/htdocs/langs/en_US/bills.lang
@@ -164,6 +164,7 @@ BillFrom=From
 BillTo=To
 ShippingTo=Shipping to
 ActionsOnBill=Actions on invoice
+InvoicesGeneratedFromRec=Generated invoices
 RecurringInvoiceTemplate=Template / Recurring invoice
 NoQualifiedRecurringInvoiceTemplateFound=No recurring template invoice qualified for generation.
 FoundXQualifiedRecurringInvoiceTemplate=Found %s recurring template invoice(s) qualified for generation.


### PR DESCRIPTION
Backport depuis la develop (future 21.0) de la feature [#31463](https://github.com/Dolibarr/dolibarr/pull/31463) qui ajoute un onglet sur les fiches des factures modèles (client et fournisseur) pour voir les factures générées depuis le modèle.