### PR TITLE
Fix fatal resource box

### DIFF
--- a/htdocs/core/boxes/box_dolibarr_state_board.php
+++ b/htdocs/core/boxes/box_dolibarr_state_board.php
@@ -161,7 +161,7 @@ class box_dolibarr_state_board extends ModeleBoxes
 				'expensereports' => 'ExpenseReport',
 				'holidays' => 'Holiday',
 				'ticket' => 'Ticket',
-				'dolresource' => 'Dolresource'
+				'dolresource' => 'DolResource'
 			);
 			$includes = array(
 				'users' => DOL_DOCUMENT_ROOT . "/user/class/user.class.php",
@@ -185,7 +185,7 @@ class box_dolibarr_state_board extends ModeleBoxes
 				'expensereports' => DOL_DOCUMENT_ROOT . "/expensereport/class/expensereport.class.php",
 				'holidays' => DOL_DOCUMENT_ROOT . "/holiday/class/holiday.class.php",
 				'ticket' => DOL_DOCUMENT_ROOT . "/ticket/class/ticket.class.php",
-				'resource' => DOL_DOCUMENT_ROOT . "/resource/class/dolresource.class.php"
+				'dolresource' => DOL_DOCUMENT_ROOT . "/resource/class/dolresource.class.php"
 			);
 			$links = array(
 				'users' => DOL_URL_ROOT . '/user/list.php',

--- a/htdocs/resource/class/dolresource.class.php
+++ b/htdocs/resource/class/dolresource.class.php
@@ -1291,6 +1291,37 @@ class DolResource extends CommonObject
 
 		return $error;
 	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.ScopeNotCamelCaps
+	/**
+	 *      Charge indicateurs this->nb de tableau de bord
+	 *
+	 *      @return     int         <0 if KO, >0 if OK
+	 */
+	public function load_state_board()
+	{
+		// phpcs:enable
+		global $conf;
+
+		$this->nb = array();
+
+		$sql = "SELECT count(r.rowid) as nb";
+		$sql .= " FROM ".MAIN_DB_PREFIX."resource as r";
+		$sql .= " WHERE r.entity IN (".getEntity('resource').")";
+
+		$resql = $this->db->query($sql);
+		if ($resql) {
+			while ($obj = $this->db->fetch_object($resql)) {
+				$this->nb["dolresource"] = $obj->nb;
+			}
+			$this->db->free($resql);
+			return 1;
+		} else {
+			dol_print_error($this->db);
+			$this->error = $this->db->error();
+			return -1;
+		}
+	}
 }
 
 


### PR DESCRIPTION
FIX Fatale sur la page d'accueil : en modifiant le fichier resource dans des devs précédents, le nommage avait mal été rétabli + une fonction importante avait disparue