### PR TITLE
FIX - Ajout d'un caractère spécial pour faire fonctionner des extrafields - DA025922

### DIFF
--- a/ChangeLog_cdcconseil
+++ b/ChangeLog_cdcconseil
@@ -1,3 +1,4 @@
+- FIX/SUPPORT/DA025922/SetSpecialCharacter - *30/12/2024*
 - FIX/SUPPORT/DA025737/HIDDEN_DROPDOWN - *19/12/2024*
 - FIX/SUPPORT/DA025871/FiltreEvalListe - **16/12/2024**
 - FIX/SUPPORT/DA025787/HRM_closed_job_position_on_application - *04/12/2024*

--- a/ChangeLog_cdcconseil
+++ b/ChangeLog_cdcconseil
@@ -1,4 +1,4 @@
-- FIX/SUPPORT/DA025922/SetSpecialCharacter - *30/12/2024*
+- FIX/SUPPORT/DA025922/SetSpecialCharacter because the character '<' was not set into the whitelist  of special character which causes an issue when you try to fetch this type of extrafields - *30/12/2024*
 - FIX/SUPPORT/DA025737/HIDDEN_DROPDOWN - *19/12/2024*
 - FIX/SUPPORT/DA025871/FiltreEvalListe - **16/12/2024**
 - FIX/SUPPORT/DA025787/HRM_closed_job_position_on_application - *04/12/2024*

--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -10308,7 +10308,7 @@ function dol_eval($s, $returnvalue = 1, $hideerrors = 1, $onlysimplestring = '1'
 			// We must accept with 2: (($reloadedobj = new Task($db)) && ($reloadedobj->fetchNoCompute($object->id) > 0) && ($secondloadedobj = new Project($db)) && ($secondloadedobj->fetchNoCompute($reloadedobj->fk_project) > 0)) ? $secondloadedobj->ref : "Parent project not found"
 
 			// Check if there is dynamic call (first we check chars are all into use a whitelist chars)
-			$specialcharsallowed = '^$_+-.*>&|=!?():"\',/@';
+			$specialcharsallowed = '^$_+-.*><&|=!?():"\',/@';
 			if ($onlysimplestring == '2') {
 				$specialcharsallowed .= '[]';
 			}


### PR DESCRIPTION

# FIX|Fix #DA025922 - Ajout d'un caractère spécial pour faire fonctionner des extrafields

Message d'erreur :
Bad string syntax to evaluate (found chars that are not chars for a simple clean eval string): $object->array_options['options_anciennete'] % 72 <= 74 ? 'Oui' : 'Non'

Ce message apparaît lorsque l'on tente de utiliser un caractère spécial qui n'est pas renseigner dans les caractères spéciaux autorisés. 


