### PR TITLE
Install maximum php version found in check.php

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -42,25 +42,6 @@ jobs:
         with:
           path: ~/.cache/pre-commit/
           key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
-      # Run all the precommit tools (defined into pre-commit-config.yaml).
-      # We can force exclusion of some of them here.
-      - name: Run pre-commit hooks
-        env:
-          # SKIP is used by pre-commit to not execute certain hooks
-          SKIP: no-commit-to-branch,php-cs,php-cbf,trailing-whitespace,end-of-file-fixer,check-json,check-executables-have-shebangs,check-shebang-scripts-are-executable,beautysh,yamllint,shellcheck
-        run: |
-          set -o pipefail
-          pre-commit gc
-          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
-
-      # The next uses git, which is slow for a bit repo.
-      # - name: Get all changed php files (if PR)
-      #   id: changed-php
-      #   uses: tj-actions/changed-files@v42
-      #   if: github.event_name == 'pull_request'
-      #   with:
-      #     files: |
-      #        **.php
 
       - name: Extract PHP version
         id: extract-php-version
@@ -85,6 +66,26 @@ jobs:
           php-version: ${{ env.PHP_VERSION }}  # Version from check.php
           coverage: none # disable xdebug, pcov
           tools: phpcs
+
+      # Run all the precommit tools (defined into pre-commit-config.yaml).
+      # We can force exclusion of some of them here.
+      - name: Run pre-commit hooks
+        env:
+          # SKIP is used by pre-commit to not execute certain hooks
+          SKIP: no-commit-to-branch,php-cs,php-cbf,trailing-whitespace,end-of-file-fixer,check-json,check-executables-have-shebangs,check-shebang-scripts-are-executable,beautysh,yamllint,shellcheck
+        run: |
+          set -o pipefail
+          pre-commit gc
+          pre-commit run --show-diff-on-failure --color=always --all-files | tee ${RAW_LOG}
+
+      # The next uses git, which is slow for a bit repo.
+      # - name: Get all changed php files (if PR)
+      #   id: changed-php
+      #   uses: tj-actions/changed-files@v42
+      #   if: github.event_name == 'pull_request'
+      #   with:
+      #     files: |
+      #        **.php
 
       - name: Run some pre-commit hooks on selected changed files only
         if: steps.changed-php.outputs.any_changed == 'true'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -51,17 +51,7 @@ jobs:
 
       - name: Setup PHPCS
         uses: shivammathur/setup-php@v2
-        # Install when we're going to run phpcs
-        if: |
-          steps.changed-php.outputs.any_changed == 'true'
-          ||
-          (
-            github.event_name == 'push'
-            && (
-                 github.event.ref == 'refs/heads/develop'
-               || endsWith(github.event.ref, '.0')
-            )
-          )
+        # Install proper php version, and also install phpcs which may be needed
         with:
           php-version: ${{ env.PHP_VERSION }}  # Version from check.php
           coverage: none # disable xdebug, pcov

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -62,6 +62,12 @@ jobs:
       #     files: |
       #        **.php
 
+      - name: Extract PHP version
+        id: extract-php-version
+        run: |
+          PHP_VERSION=$(sed -n 's/.*\$arrayphpmaxversionwarning\s*=\s*array\s*(\s*\([0-9]\+\)\s*,\s*\([0-9]\+\).*/\1.\2/p' htdocs/install/check.php)
+          echo "PHP_VERSION=$PHP_VERSION" >> $GITHUB_ENV
+
       - name: Setup PHPCS
         uses: shivammathur/setup-php@v2
         # Install when we're going to run phpcs
@@ -76,7 +82,7 @@ jobs:
             )
           )
         with:
-          php-version: 8.1
+          php-version: ${{ env.PHP_VERSION }}  # Version from check.php
           coverage: none # disable xdebug, pcov
           tools: phpcs
 


### PR DESCRIPTION
# Install maximum php version found in check.php

This installs the maximum php version found in check.php BEFORE running the pre-commit step itself so that the phplint operation is using that maximum php-version.
While in 17.0 the explicit value in the pre-commit action configuration and check.php are both 8.1, this also makes the configuration future proof so that it automatically evolves with version requirements for dolibarr.