### PR TITLE
FIX 17.0 (backport PR #33606): unset fk_user_cloture when reopening a contract line

### DIFF
--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -3581,6 +3581,7 @@ class ContratLigne extends CommonObjectLine
 		}
 		$sql .= " fk_user_ouverture = ".((int) $this->fk_user_ouverture).",";
 		$sql .= " date_cloture = null,";
+		$sql .= " fk_user_cloture = null,";
 		$sql .= " commentaire = '".$this->db->escape($comment)."'";
 		$sql .= " WHERE rowid = ".((int) $this->id)." AND (statut = ".ContratLigne::STATUS_INITIAL." OR statut = ".ContratLigne::STATUS_CLOSED.")";
 


### PR DESCRIPTION
Backport of [Dolibarr/dolibarr#33606](https://github.com/Dolibarr/dolibarr/pull/33606)

