### PR TITLE
FIX critical bug: extrafields of object replaced with extrafields of line when calling `fetch_lines()`

### DIFF
--- a/ChangeLog_Koesio.md
+++ b/ChangeLog_Koesio.md
@@ -1,21 +1,22 @@
-## Backported from 17.0 :
-- Backport develop PR #33809 : putLine contract endpoint: hidden conf `API_CONTRAT_PUTLINE_OUTPUT_LINE_ONLY` to only get the updated line in the output instead of the whole contract - **10/04/2025**
+## Backported from 17.0:
+- Backport develop PR #33891: FIX critical bug (extrafields of parent replaced with extrafields of line during `fetch_lines()`)
+- Backport develop PR #33809: putLine contract endpoint: hidden conf `API_CONTRAT_PUTLINE_OUTPUT_LINE_ONLY` to only get the updated line in the output instead of the whole contract - **10/04/2025**
 - Backport develop PR #33771: Add hook printObjectLinesBlock in contract cards - **09/04/2025**
-- Backport develop PR #33257 : Grouped fetch and fetch optionals for every document - **03/04/2025**
-- Backport develop PR #33222 : getLines contract endpoint with sql filters and pagination - **01/04/2025**
-- Backport 17.0 PR #33505 : removed useless $prod->fetch() - **19/03/2025**
-- Backport develop PR #33460 : removed useless fetch product for a SQL request
-- Backport develop PR #33641 : hook printObjectLinesBlock - *2025-03-04*
-- Backport develop PR #33314 : hook completeFieldsToSearchAll on thirdparty list
-- Backport develop PR #32662 : New hooks in services_list and added global search
-- Backport 17.0 PR #32654 : Search thirdparty in services list
-- Backport develop PR #32129 : New field rule for lines dates
-- Backport 17.0 PR #32247 : added error message in cron
-- Backport develop : fix abs fatal error
-- Backport develop PR 31267 : fix error in code, putline() function in api contract overwrote the data that was not updated by the api - *2024-11-25*
-- Backport 21.0 PR #31698 : management rib select in fac rec card - *2024-11-14*
-- Backport  17.0 PR #30899 : multiselect rib - *2024-10-30*
-- Backport  17.0 PR #31623 : Suspend facture rec when nb gen max is reached - *2024-10-29*
-- Backport  21.0 PR #31463 : Tab to see generated invoices on recurring 
+- Backport develop PR #33257: Grouped fetch and fetch optionals for every document - **03/04/2025**
+- Backport develop PR #33222: getLines contract endpoint with sql filters and pagination - **01/04/2025**
+- Backport 17.0 PR #33505: removed useless $prod->fetch() - **19/03/2025**
+- Backport develop PR #33460: removed useless fetch product for a SQL request
+- Backport develop PR #33641: hook printObjectLinesBlock - *2025-03-04*
+- Backport develop PR #33314: hook completeFieldsToSearchAll on thirdparty list
+- Backport develop PR #32662: New hooks in services_list and added global search
+- Backport 17.0 PR #32654: Search thirdparty in services list
+- Backport develop PR #32129: New field rule for lines dates
+- Backport 17.0 PR #32247: added error message in cron
+- Backport develop: fix abs fatal error
+- Backport develop PR 31267: fix error in code, putline() function in api contract overwrote the data that was not updated by the api - *2024-11-25*
+- Backport 21.0 PR #31698: management rib select in fac rec card - *2024-11-14*
+- Backport  17.0 PR #30899: multiselect rib - *2024-10-30*
+- Backport  17.0 PR #31623: Suspend facture rec when nb gen max is reached - *2024-10-29*
+- Backport  21.0 PR #31463: Tab to see generated invoices on recurring 
   supplier or customer invoice cards - *2024-10-23*
-- Backport  17.0 PR #31445 : Follow ExtraFields between model invoice and classic invoice - *2024-10-18*
+- Backport  17.0 PR #31445: Follow ExtraFields between model invoice and classic invoice - *2024-10-18*

--- a/htdocs/comm/propal/class/propal.class.php
+++ b/htdocs/comm/propal/class/propal.class.php
@@ -2029,7 +2029,7 @@ class Propal extends CommonObject
 				$line->multicurrency_total_ttc 	= $objp->multicurrency_total_ttc;
 
 				// Now process extrafields
-				$this->array_options = array();
+				$line->array_options = array();
 				if ($doFetchInOneSqlRequest && $extraFieldsCheck) {
 					foreach ($extrafields->attributes[$this->table_element_line]['label'] as $key => $val) {
 						if (empty($extrafields->attributes[$this->table_element_line]['type'][$key]) || $extrafields->attributes[$this->table_element_line]['type'][$key] != 'separate') {
@@ -2037,9 +2037,9 @@ class Propal extends CommonObject
 
 							// Process date/datetime fields
 							if (!empty($extrafields->attributes[$this->table_element_line]) && in_array($extrafields->attributes[$this->table_element_line]['type'][$key], array('date', 'datetime'))) {
-								$this->array_options["options_".$key] = $this->db->jdate($objp->$keyname);
+								$line->array_options["options_".$key] = $this->db->jdate($objp->$keyname);
 							} else {
-								$this->array_options["options_".$key] = $objp->$keyname;
+								$line->array_options["options_".$key] = $objp->$keyname;
 							}
 						}
 					}
@@ -2050,8 +2050,8 @@ class Propal extends CommonObject
 							if (!empty($extrafields->attributes[$this->table_element_line]) && !empty($extrafields->attributes[$this->table_element_line]['computed'][$key])) {
 								if (empty($conf->disable_compute)) {
 									global $objectoffield;    // We set a global variable to $objectoffield so
-									$objectoffield = $this;   // we can use it inside computed formula
-									$this->array_options['options_' . $key] = dol_eval($extrafields->attributes[$this->table_element_line]['computed'][$key], 1, 0, '2');
+									$objectoffield = $line;   // we can use it inside computed formula
+									$line->array_options['options_' . $key] = dol_eval($extrafields->attributes[$this->table_element_line]['computed'][$key], 1, 0, '2');
 								}
 							}
 						}

--- a/htdocs/commande/class/commande.class.php
+++ b/htdocs/commande/class/commande.class.php
@@ -2284,7 +2284,7 @@ class Commande extends CommonOrder
 				$line->multicurrency_total_ttc 	= $objp->multicurrency_total_ttc;
 
 				// Now process extrafields
-				$this->array_options = array();
+				$line->array_options = array();
 				if ($doFetchInOneSqlRequest && $extraFieldsCheck) {
 					foreach ($extrafields->attributes[$this->table_element_line]['label'] as $key => $val) {
 						if (empty($extrafields->attributes[$this->table_element_line]['type'][$key]) || $extrafields->attributes[$this->table_element_line]['type'][$key] != 'separate') {
@@ -2292,9 +2292,9 @@ class Commande extends CommonOrder
 
 							// Process date/datetime fields
 							if (!empty($extrafields->attributes[$this->table_element_line]) && in_array($extrafields->attributes[$this->table_element_line]['type'][$key], array('date', 'datetime'))) {
-								$this->array_options["options_".$key] = $this->db->jdate($objp->$keyname);
+								$line->array_options["options_".$key] = $this->db->jdate($objp->$keyname);
 							} else {
-								$this->array_options["options_".$key] = $objp->$keyname;
+								$line->array_options["options_".$key] = $objp->$keyname;
 							}
 						}
 					}
@@ -2305,8 +2305,8 @@ class Commande extends CommonOrder
 							if (!empty($extrafields->attributes[$this->table_element_line]) && !empty($extrafields->attributes[$this->table_element_line]['computed'][$key])) {
 								if (empty($conf->disable_compute)) {
 									global $objectoffield;    // We set a global variable to $objectoffield so
-									$objectoffield = $this;   // we can use it inside computed formula
-									$this->array_options['options_' . $key] = dol_eval($extrafields->attributes[$this->table_element_line]['computed'][$key], 1, 0, '2');
+									$objectoffield = $line;   // we can use it inside computed formula
+									$line->array_options['options_' . $key] = dol_eval($extrafields->attributes[$this->table_element_line]['computed'][$key], 1, 0, '2');
 								}
 							}
 						}

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -2333,7 +2333,7 @@ class Facture extends CommonInvoice
 				$line->multicurrency_total_ttc 	= $objp->multicurrency_total_ttc;
 
 				// Now process extrafields
-				$this->array_options = array();
+				$line->array_options = array();
 				if ($doFetchInOneSqlRequest && $extraFieldsCheck) {
 					foreach ($extrafields->attributes[$this->table_element_line]['label'] as $key => $val) {
 						if (empty($extrafields->attributes[$this->table_element_line]['type'][$key]) || $extrafields->attributes[$this->table_element_line]['type'][$key] != 'separate') {
@@ -2341,9 +2341,9 @@ class Facture extends CommonInvoice
 
 							// Process date/datetime fields
 							if (!empty($extrafields->attributes[$this->table_element_line]) && in_array($extrafields->attributes[$this->table_element_line]['type'][$key], array('date', 'datetime'))) {
-								$this->array_options["options_".$key] = $this->db->jdate($objp->$keyname);
+								$line->array_options["options_".$key] = $this->db->jdate($objp->$keyname);
 							} else {
-								$this->array_options["options_".$key] = $objp->$keyname;
+								$line->array_options["options_".$key] = $objp->$keyname;
 							}
 						}
 					}
@@ -2354,8 +2354,8 @@ class Facture extends CommonInvoice
 							if (!empty($extrafields->attributes[$this->table_element_line]) && !empty($extrafields->attributes[$this->table_element_line]['computed'][$key])) {
 								if (empty($conf->disable_compute)) {
 									global $objectoffield;    // We set a global variable to $objectoffield so
-									$objectoffield = $this;   // we can use it inside computed formula
-									$this->array_options['options_' . $key] = dol_eval($extrafields->attributes[$this->table_element_line]['computed'][$key], 1, 0, '2');
+									$objectoffield = $line;   // we can use it inside computed formula
+									$line->array_options['options_' . $key] = dol_eval($extrafields->attributes[$this->table_element_line]['computed'][$key], 1, 0, '2');
 								}
 							}
 						}

--- a/htdocs/contrat/class/contrat.class.php
+++ b/htdocs/contrat/class/contrat.class.php
@@ -1008,7 +1008,7 @@ class Contrat extends CommonObject
 							if (!empty($extrafields->attributes[$this->table_element_line]) && !empty($extrafields->attributes[$this->table_element_line]['computed'][$key])) {
 								if (empty($conf->disable_compute)) {
 									global $objectoffield;    // We set a global variable to $objectoffield so
-									$objectoffield = $this;   // we can use it inside computed formula
+									$objectoffield = $line;   // we can use it inside computed formula
 									$line->array_options['options_' . $key] = dol_eval($extrafields->attributes[$this->table_element_line]['computed'][$key], 1, 0, '2');
 								}
 							}


### PR DESCRIPTION
cf. Dolibarr#33891
