### PR TITLE
FIX - DA026519 - input hidden print on form mail of ticket

### DIFF
--- a/ChangeLogAtm.md
+++ b/ChangeLogAtm.md
@@ -1,3 +1,4 @@
+- FIX: #DA026519 - input hidden did not work properly on form mail of ticket module
 - FIX create/edit ticket forms
 - Backport from 20.0 :
   - Added hook into getElementProperties to handle $element_properties array

--- a/htdocs/admin/ticket.php
+++ b/htdocs/admin/ticket.php
@@ -688,7 +688,7 @@ print '</td>';
 print '</tr>';
 
 // Message header
-$mail_intro = getDolGlobalString('TICKET_MESSAGE_MAIL_INTRO', '');
+$mail_intro = htmlspecialchars_decode(getDolGlobalString('TICKET_MESSAGE_MAIL_INTRO', ''));
 print '<tr class="oddeven"><td>'.$langs->trans("TicketMessageMailIntro");
 print '</td><td>';
 require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
@@ -700,7 +700,7 @@ print $formcategory->textwithpicto('', $langs->trans("TicketMessageMailIntroHelp
 print '</td></tr>';
 
 // Message footer
-$mail_signature = getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE');
+$mail_signature = htmlspecialchars_decode(getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE'));
 print '<tr class="oddeven"><td>'.$langs->trans("TicketMessageMailFooter").'</label>';
 print '</td><td>';
 require_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';

--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -1843,12 +1843,12 @@ class FormTicket
 			}
 			if (getDolGlobalString('TICKET_MESSAGE_MAIL_INTRO')) {
 				$mail_intro = make_substitutions(getDolGlobalString('TICKET_MESSAGE_MAIL_INTRO'), $this->substit);
-				print '<input type="hidden" name="mail_intro" value="'.$mail_intro.'">';
+				print '<input type="hidden" name="mail_intro" value="'.htmlspecialchars($mail_intro, ENT_QUOTES).'">';
 				$texttooltip .= '<br><u>'.$langs->trans("TicketMessageMailIntro").'</u><br>'.$mail_intro;
 			}
 			if (getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE')) {
 				$mail_signature = make_substitutions(getDolGlobalString('TICKET_MESSAGE_MAIL_SIGNATURE'), $this->substit);
-				print '<input type="hidden" name="mail_signature" value="'.$mail_signature.'">';
+				print '<input type="hidden" name="mail_signature" value="'.htmlspecialchars($mail_signature, ENT_QUOTES) .'">';
 				$texttooltip .= '<br><br><u>'.$langs->trans("TicketMessageMailFooter").'</u><br>'.$mail_signature;
 			}
 			print $form->textwithpicto('', $texttooltip, 1, 'help');


### PR DESCRIPTION
Problem encountered (Ticket module)

In the ticket module, when HTML links are used in the message header or footer configuration fields, a display issue occurs for private messages and for email sending above the ticket form.

If these fields contain an HTML link, and the value is injected into a <input type="hidden">, the presence of the HTML tag breaks the markup: everything after the link is incorrectly displayed above the form, resulting in misplaced content and incorrect rendering (truncated links, shifted display, broken HTML structure, etc.).

Solution implemented

The implemented solution is to properly decode HTML entities (using ) when retrieving the signature from the hidden input in the ticket module.

This now allows the original HTML content (including links) to be correctly rendered in both forms and emails, without disrupting the page’s structure or display htmlspecialchars_decode