### PR TITLE
Backport 17.0 PR #34777 and #34778: `Facture::update()` fails when ca…

### DIFF
--- a/ChangeLog_Koesio.md
+++ b/ChangeLog_Koesio.md
@@ -1,4 +1,5 @@
 ## Backported from 17.0:
+- Backport 17.0 PR #34777 and #34778: `Facture::update()` fails when called in a trigger after `createFromClone()` + the clone of a template-generated invoice should not be linked to the template.
 - Backport develop PR #34293: Ajout $properties et $lines dans les API de contracts et invoices pour la gestion des données - *2025-05-27*
 - Backport develop PR #33891: FIX critical bug (extrafields of parent replaced with extrafields of line during `fetch_lines()`)
 - Backport develop PR #33809: putLine contract endpoint: hidden conf `API_CONTRAT_PUTLINE_OUTPUT_LINE_ONLY` to only get the updated line in the output instead of the whole contract - **10/04/2025**

--- a/htdocs/compta/facture/class/facture.class.php
+++ b/htdocs/compta/facture/class/facture.class.php
@@ -1257,7 +1257,7 @@ class Facture extends CommonInvoice
 				$object->socid = $objsoc->id;
 				$object->cond_reglement_id	= (!empty($objsoc->cond_reglement_id) ? $objsoc->cond_reglement_id : 0);
 				$object->mode_reglement_id	= (!empty($objsoc->mode_reglement_id) ? $objsoc->mode_reglement_id : 0);
-				$object->fk_project = '';
+				$object->fk_project = null;
 				$object->fk_delivery_address = '';
 			}
 
@@ -1274,7 +1274,8 @@ class Facture extends CommonInvoice
 		$object->user_valid         = null; // deprecated
 		$object->fk_user_author     = $user->id;
 		$object->fk_user_valid      = null;
-		$object->fk_facture_source  = 0;
+		$object->fk_facture_source  = null;
+		$object->fk_fac_rec_source  = null;
 		$object->date_creation      = '';
 		$object->date_modification = '';
 		$object->date_validation    = '';


### PR DESCRIPTION
…lled in a trigger after `createFromClone()` + the clone of a template-generated invoice should not be linked to the template.

## refs:
cf. Dolibarr#34777 and Dolibarr#34778