### PR TITLE
NEW [SP148] : TK2508-3901 - Backport de l'onglet "Fournisseur" des fiches tiers

### DIFF
--- a/ChangeLog_Koesio.md
+++ b/ChangeLog_Koesio.md
@@ -1,4 +1,5 @@
 ## Backported from 17.0:
+- Backport develop fourn/card.php : add hook & manage product list displat - **01/09/2025**
 - Backport 17.0 PR #34777 and #34778: `Facture::update()` fails when called in a trigger after `createFromClone()` + the clone of a template-generated invoice should not be linked to the template.
 - Backport develop PR #34293: Ajout $properties et $lines dans les API de contracts et invoices pour la gestion des données - *2025-05-27*
 - Backport develop PR #33891: FIX critical bug (extrafields of parent replaced with extrafields of line during `fetch_lines()`)

--- a/htdocs/fourn/card.php
+++ b/htdocs/fourn/card.php
@@ -533,7 +533,12 @@ if ($object->id > 0) {
 
 
 	/*
-	 * List of products
+	 * Backport TK2508-3901
+	 * Tout ce qui suit a été récupéré du même fichier en version 23.0
+	 */
+
+	/*
+	 * List of products prices
 	 */
 	if (isModEnabled("product") || isModEnabled("service")) {
 		$langs->load("products");
@@ -557,7 +562,7 @@ if ($object->id > 0) {
 		print '<div class="div-table-responsive-no-min">';
 		print '<table class="noborder centpercent lastrecordtable">';
 		print '<tr class="liste_titre'.(($num == 0) ? ' nobottom' : '').'">';
-		print '<td colspan="3">'.$langs->trans("ProductsAndServices").'</td><td class="right">';
+		print '<td colspan="2">'.$langs->trans("ProductsAndServices").'</td><td class="right" colspan="2">';
 		print '<a class="notasortlink" href="'.DOL_URL_ROOT.'/fourn/product/list.php?fourn_id='.$object->id.'"><span class="hideonsmartphone">'.$langs->trans("AllProductReferencesOfSupplier").'</span><span class="badge marginleftonlyshort">'.$object->nbOfProductRefs().'</span>';
 		print '</a></td></tr>';
 
@@ -582,7 +587,7 @@ if ($object->id > 0) {
 				print '<td>';
 				print dol_escape_htmltag($objp->supplier_ref);
 				print '</td>';
-				print '<td class="maxwidthonsmartphone">';
+				print '<td class="tdoverflowmax200">';
 				print dol_trunc(dol_htmlentities($objp->label), 30);
 				print '</td>';
 				//print '<td class="right" class="nowrap">'.dol_print_date($objp->tms, 'day').'</td>';
@@ -598,12 +603,17 @@ if ($object->id > 0) {
 				print '</td>';
 				print '</tr>';
 			}
+		} else {
+			print '<tr><td colspan="4"><span class="opacitymedium">'.$langs->trans("NoProductPriceDefinedForThisSupplier").'</span></td></tr>';
 		}
 
 		print '</table>';
 		print '</div>';
 	}
 
+	/*
+	 * Fin du backport TK2508-3901
+	 */
 
 	/*
 	 * Latest supplier proposal
@@ -843,6 +853,24 @@ if ($object->id > 0) {
 			dol_print_error($db);
 		}
 	}
+
+	/*
+	 * Backport TK2508-3901
+	 * Tout ce qui suit a été récupéré du même fichier en version 23.0
+	 */
+
+	// Allow external modules to add their own shortlist of recent objects
+	$parameters = array();
+	$reshook = $hookmanager->executeHooks('addMoreRecentObjects', $parameters, $object, $action);
+	if ($reshook < 0) {
+		setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+	} else {
+		print $hookmanager->resPrint;
+	}
+
+	/*
+ 	* Fin du backport TK2508-3901
+	*/
 
 	print '</div></div>';
 	print '<div style="clear:both"></div>';

--- a/htdocs/langs/fr_FR/products.lang
+++ b/htdocs/langs/fr_FR/products.lang
@@ -143,6 +143,7 @@ WithoutDiscount=Sans remise
 VATRateForSupplierProduct=Taux TVA (pour ce produit/fournisseur)
 DiscountQtyMin=Remise pour cette qté.
 NoPriceDefinedForThisSupplier=Aucun prix/qté défini pour ce fournisseur/produit
+NoProductPriceDefinedForThisSupplier=Aucun produit prix/quantité défini pour ce fournisseur
 NoSupplierPriceDefinedForThisProduct=Aucun prix/qté fournisseur défini pour ce produit
 PredefinedItem=Article prédéfini
 PredefinedProductsToSell=Produits prédéfinis en vente


### PR DESCRIPTION
## NEW [SP148] : TK2508-3901 - Backport de l'onglet "Fournisseur" des fiche tiers

Backport de la partie "Produit" de l'onglet "Fournisseur" des fiches tiers depuis la v23.0 standard. 
Backport du hook **addMoreRecentObjects** qui n'était pas encore présent en v17.0
