### PR TITLE
FIX  SP153 : mrp list extrafield duration format

### DIFF
--- a/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
+++ b/htdocs/core/tpl/extrafields_list_print_fields.tpl.php
@@ -96,6 +96,14 @@ if (!empty($extrafieldsobjectkey) && !empty($extrafields->attributes[$extrafield
 						$totalarray['nbfield'] = 0;
 					}
 					$totalarray['nbfield']++;
+					// backport a supprimer lorsque la solutions sera merge en v22
+					if (!empty($extrafields->attributes[$extrafieldsobjectkey]['type'][$key]) && $extrafields->attributes[$extrafieldsobjectkey]['type'][$key] === 'duration') {
+						if (empty($totalarray['type']) || !is_array($totalarray['type'])) {
+							$totalarray['type'] = array();
+						}
+						$totalarray['type'][$totalarray['nbfield']] = 'duration';
+					}
+					// end backport
 				}
 
 				if (!empty($extrafields->attributes[$extrafieldsobjectkey]['totalizable'][$key])) {


### PR DESCRIPTION
# FIX|Fix #*mrp list extrafield duration format*

Before the modification, extrafields_list_print_fields.tpl.php correctly incremented the total of the totalable extrafield columns, but never recorded their type (duration, price, etc.) in $totalarray.
The generic template list_print_total.tpl.php therefore assumed it was a standard numeric amount and passed the value to price(), hence the display in seconds. By adding the writing of duration when the extrafield type is a duration, printTotalValCell() now knows to use convertSecondToTime() without waiting for a hook to do it manually.

