### PR TITLE
FIX TCPDF Fatals due to transaction mechanism problems

### DIFF
--- a/ChangeLog_epox3000
+++ b/ChangeLog_epox3000
@@ -1,4 +1,5 @@
 ***** ChangeLog for epoxy_3000  *****
+FIX : DA027393 - TCPDF Fatal (le rollback d'une transaction supprime des variables indispensables sans les restaurer)
 NEW : DA026607 - BACKPORT V22 - Rajout d'une conf divers pour activer ou non l'affichage des objects liés dans les notes public des pdf'
 FIX : DA026578 - Lignes désordonnées au clone d'une commande
 FIX : Modification du comportment de saisi des tâches afin de pouvoir saisir du temps sur un projet même si le projet ne contient pas de contact assigné - **28/05/2025**

--- a/htdocs/includes/tecnickcom/tcpdf/tcpdf.php
+++ b/htdocs/includes/tecnickcom/tcpdf/tcpdf.php
@@ -22133,7 +22133,12 @@ class TCPDF
 	public function rollbackTransaction($self = false)
 	{
 		if (isset($this->objcopy)) {
-			$this->_destroy(true, true);
+			// FIX spe EPOXY: diable $this->_destroy()
+			//    When called on a TCPDI or FPDF object, in some cases,
+			//    it can destroy attributes like `CoreFonts` and cause PHP Fatals.
+			//    The current state is going to be overwritten (by the restoration
+			//    of $this->objcopy) so _destroy() doesn't save much RAM.
+			// $this->_destroy(true, true);
 			if ($self) {
 				$objvars = get_object_vars($this->objcopy);
 				foreach ($objvars as $key => $value) {


### PR DESCRIPTION
C'est un bug de TCPDF (ou de TCPDI ou FPDF) dans le mécanisme de transactions.

Fonctionnement normal du mécanisme :
- quand on appelle startTransaction, on crée un clone de l'objet pdf
- quand on appelle rollbackTransaction, on supprime tous les attributs directs de l'objet PDF puis on les restaure depuis le clone.

Problème : dans certains cas, à cause de l'héritage (TCPDI qui hérite de FPDF_TPL qui hérite de FPDF qui hérite de TCPDF) à ce qu'il semble, certains attributs non sauvegardés sur le clone mais indispensables (liés aux polices chargées) sont détruits et ne sont pas restaurés, notamment `CoreFonts`, `fontkeys` etc., ce qui provoque des Fatals dès qu'on utilise les polices.

Le bug ne se produit que dans certaines conditions que je n'ai pas réussi à identifier. En l'occurrence, sur `pdf_of_commande_epoxy.modules.php`, mais uniquement sur le tout dernier rollback.