### PR TITLE
17.0 koesio kali new/161/tk2602 4140/permission

### DIFF
--- a/htdocs/core/class/html.formticket.class.php
+++ b/htdocs/core/class/html.formticket.class.php
@@ -153,6 +153,9 @@ class FormTicket
 	{
 		global $conf, $langs, $user, $hookmanager;
 
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		$permissiontomanage = $user->hasRight('ticket', 'manage');
+
 		// Load translation files required by the page
 		$langs->loadLangs(array('other', 'mails', 'ticket'));
 
@@ -627,8 +630,16 @@ class FormTicket
 			print '<tr><td>';
 			print $langs->trans("AssignedTo");
 			print '</td><td>';
-			print img_picto('', 'user', 'class="pictofixedwidth"');
-			print $form->select_dolusers(GETPOST('fk_user_assign', 'int'), 'fk_user_assign', 1);
+			// BACKPORT v24 START - https://github.com/Dolibarr/dolibarr/pull/37490
+			if ($permissiontomanage) {
+				print img_picto('', 'user', 'class="pictofixedwidth"');
+				print $form->select_dolusers(GETPOST('fk_user_assign', 'int'), 'fk_user_assign', 1);
+			} else {
+				$userstat = new User($this->db);
+				$userstat->fetch(GETPOST('fk_user_assign', 'int'));
+				print $userstat->getNomUrl(-1);
+			}
+			// BACKPORT v24 END - https://github.com/Dolibarr/dolibarr/pull/37490
 			print '</td>';
 			print '</tr>';
 		}

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -130,6 +130,7 @@ $result = restrictedArea($user, 'ticket', $object->id);
 $triggermodname = 'TICKET_MODIFY';
 $permissiontoread = $user->hasRight('ticket', 'read');
 $permissiontoadd = $user->hasRight('ticket', 'write');
+// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 $permissiontomanage = $user->hasRight('ticket', 'manage');
 $permissiontodelete = $user->hasRight('ticket', 'delete');
 
@@ -268,7 +269,8 @@ if (empty($reshook)) {
 				}
 
 				// Auto mark as read if created from backend
-				if (!empty($conf->global->TICKET_AUTO_READ_WHEN_CREATED_FROM_BACKEND) && $user->rights->ticket->write) {
+				// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+				if (!empty($conf->global->TICKET_AUTO_READ_WHEN_CREATED_FROM_BACKEND) && $permissiontomanage) {
 					if ( ! $object->markAsRead($user) > 0) {
 						setEventMessages($object->error, $object->errors, 'errors');
 					}
@@ -376,6 +378,7 @@ if (empty($reshook)) {
 	}
 
 	// Mark as Read
+	// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 	if ($action == "mark_ticket_read" && $permissiontomanage) {
 		$object->fetch('', '', GETPOST("track_id", 'alpha'));
 
@@ -391,6 +394,7 @@ if (empty($reshook)) {
 	}
 
 	// Assign to someone
+	// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 	if ($action == "assign_user" && GETPOST('btn_assign_user', 'alpha') && $permissiontomanage) {
 		$object->fetch('', '', GETPOST("track_id", 'alpha'));
 		$useroriginassign = $object->fk_user_assign;
@@ -468,6 +472,7 @@ if (empty($reshook)) {
 		}
 	}
 
+	// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 	if (($action == "confirm_close" || $action == "confirm_abandon") && GETPOST('confirm', 'alpha') == 'yes' && $permissiontomanage) {
 		$object->fetch(GETPOST('id', 'int'), '', GETPOST('track_id', 'alpha'));
 
@@ -515,7 +520,8 @@ if (empty($reshook)) {
 	}
 
 	// Set parent company
-	if ($action == 'set_thirdparty' && $user->rights->ticket->write) {
+	// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+	if ($action == 'set_thirdparty' && $permissiontoadd) {
 		if ($object->fetch(GETPOST('id', 'int'), '', GETPOST('track_id', 'alpha')) >= 0) {
 			$result = $object->setCustomer(GETPOST('editcustomer', 'int'));
 			$url = 'card.php?track_id='.GETPOST('track_id', 'alpha');
@@ -524,7 +530,9 @@ if (empty($reshook)) {
 		}
 	}
 
-	if ($action == 'set_progression' && $user->rights->ticket->write) {
+	// Set progress status
+	// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+	if ($action == 'set_progression' && $permissiontoadd) {
 		if ($object->fetch(GETPOST('id', 'int'), '', GETPOST('track_id', 'alpha')) >= 0) {
 			$result = $object->setProgression(GETPOST('progress', 'alpha'));
 
@@ -534,7 +542,9 @@ if (empty($reshook)) {
 		}
 	}
 
-	if ($action == 'set_categories' && $user->rights->ticket->write) {
+	// Set categories
+	// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+	if ($action == 'set_categories' && $permissiontoadd) {
 		if ($object->fetch(GETPOST('id', 'int'), '', GETPOST('track_id', 'alpha')) >= 0) {
 			$result = $object->setCategories(GETPOST('categories', 'array'));
 
@@ -544,7 +554,9 @@ if (empty($reshook)) {
 		}
 	}
 
-	if ($action == 'setsubject' && $user->rights->ticket->write) {
+	// Set Subject
+	// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+	if ($action == 'setsubject' && $permissiontoadd) {
 		if ($object->fetch(GETPOST('id', 'int'))) {
 			if ($action == 'setsubject') {
 				$object->subject = GETPOST('subject', 'alphanohtml');
@@ -567,7 +579,8 @@ if (empty($reshook)) {
 		}
 	}
 
-	if ($action == 'confirm_reopen' && $user->rights->ticket->manage && !GETPOST('cancel')) {
+	// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+	if ($action == 'confirm_reopen' && $permissiontomanage && !GETPOST('cancel')) {
 		if ($object->fetch(GETPOST('id', 'int'), '', GETPOST('track_id', 'alpha')) >= 0) {
 			// prevent browser refresh from reopening ticket several times
 			if ($object->status == Ticket::STATUS_CLOSED || $object->status == Ticket::STATUS_CANCELED) {
@@ -604,7 +617,7 @@ if (empty($reshook)) {
 			header("Location: ".$url);
 			exit();
 		}
-	} elseif ($action == "set_message" && $user->rights->ticket->write) {
+	} elseif ($action == "set_message" && $permissiontoadd) { // BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 		if (!GETPOST('cancel')) {
 			$object->fetch('', '', GETPOST('track_id', 'alpha'));
 			$oldvalue_message = $object->message;
@@ -627,7 +640,7 @@ if (empty($reshook)) {
 		}
 
 		$action = 'view';
-	} elseif ($action == 'confirm_set_status' && $permissiontomanage && !GETPOST('cancel')) {
+	} elseif ($action == 'confirm_set_status' && $permissiontomanage && !GETPOST('cancel')) { // BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 		// Reopen ticket
 		if ($object->fetch(GETPOST('id', 'int'), GETPOST('track_id', 'alpha')) >= 0) {
 			$new_status = GETPOST('new_status', 'int');
@@ -695,7 +708,8 @@ if (empty($reshook)) {
 	}
 
 
-	$permissiondellink = $user->rights->ticket->write;
+	// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+	$permissiondellink = $permissiontoadd;
 	include DOL_DOCUMENT_ROOT.'/core/actions_dellink.inc.php'; // Must be include, not include_once
 
 	// Actions to build doc
@@ -808,11 +822,13 @@ if ($action == 'create' || $action == 'presend') {
 	|| $action == 'editsubject' || $action == 'edit_extras' || $action == 'update_extras' || $action == 'edit_extrafields' || $action == 'set_extrafields' || $action == 'classify' || $action == 'sel_contract' || $action == 'edit_message_init' || $action == 'set_status' || $action == 'dellink') {
 	if ($res > 0) {
 		// or for unauthorized internals users
-		if (!$user->socid && (!empty($conf->global->TICKET_LIMIT_VIEW_ASSIGNED_ONLY) && $object->fk_user_assign != $user->id) && !$user->rights->ticket->manage) {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if (!$user->socid && (!empty($conf->global->TICKET_LIMIT_VIEW_ASSIGNED_ONLY) && $object->fk_user_assign != $user->id) && !$permissiontomanage) {
 			accessforbidden('', 0, 1);
 		}
 
 		// Confirmation close
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 		if ($action == 'close' && $permissiontomanage) {
 			$thirdparty_contacts = $object->getInfosTicketExternalContact();
 			$contacts_select = array(
@@ -838,19 +854,23 @@ if ($action == 'create' || $action == 'presend') {
 			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("CloseATicket"), $langs->trans("ConfirmCloseAticket"), "confirm_close", $formquestion, '', 1);
 		}
 		// Confirmation abandon
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 		if ($action == 'abandon' && $permissiontomanage) {
 			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("AbandonTicket"), $langs->trans("ConfirmAbandonTicket"), "confirm_abandon", '', '', 1);
 		}
 		// Confirmation delete
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 		if ($action == 'delete' && $permissiontodelete) {
 			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("Delete"), $langs->trans("ConfirmDeleteTicket"), "confirm_delete_ticket", '', '', 1);
 		}
 		// Confirm reopen
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 		if ($action == 'reopen' && $permissiontomanage) {
 			print $form->formconfirm($url_page_current.'?track_id='.$object->track_id, $langs->trans('ReOpen'), $langs->trans('ConfirmReOpenTicket'), 'confirm_reopen', '', '', 1);
 		}
 		// Confirmation status change
-		if ($action == 'set_status') {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if ($action == 'set_status' && $permissiontomanage) {
 			$new_status = GETPOST('new_status');
 			//var_dump($url_page_current . "?track_id=" . $object->track_id);
 			print $form->formconfirm($url_page_current."?track_id=".$object->track_id."&new_status=".GETPOST('new_status'), $langs->trans("TicketChangeStatus"), $langs->trans("TicketConfirmChangeStatus", $langs->transnoentities($object->statuts_short[$new_status])), "confirm_set_status", '', '', 1);
@@ -962,7 +982,8 @@ if ($action == 'create' || $action == 'presend') {
 			$morehtmlref .= dol_escape_htmltag($object->origin_email).' <small class="hideonsmartphone opacitymedium">- '.$form->textwithpicto($langs->trans("CreatedByPublicPortal"), $htmltooptip, 1, 'help', '', 0, 3, 'tooltip').'</small>';
 		}
 
-		$permissiontoedit = $object->status < 8 && !$user->socid && $user->rights->ticket->write;
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		$permissiontoedit = $object->status < 8 && !$user->socid && $permissiontoadd;
 		//$permissiontoedit = 0;
 
 		// Thirdparty
@@ -1025,9 +1046,11 @@ if ($action == 'create' || $action == 'presend') {
 
 		// Subject
 		print '<tr><td>';
-		print $form->editfieldkey("Subject", 'subject', $object->subject, $object, $user->rights->ticket->write && !in_array($object->status, $closeStatuses) && !$user->socid, 'string');
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		print $form->editfieldkey("Subject", 'subject', $object->subject, $object, $permissiontoadd && !in_array($object->status, $closeStatuses) && !$user->socid, 'string');
 		print '</td><td>';
-		print $form->editfieldval("Subject", 'subject', $object->subject, $object, $user->rights->ticket->write && !$user->socid, 'string');
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		print $form->editfieldval("Subject", 'subject', $object->subject, $object, $$permissiontoadd && !$user->socid, 'string');
 		print '</td></tr>';
 
 		// Creation date
@@ -1073,7 +1096,8 @@ if ($action == 'create' || $action == 'presend') {
 		print '<tr><td>';
 		print '<table class="nobordernopadding" width="100%"><tr><td class="nowrap">';
 		print $langs->trans("AssignedTo");
-		if (isset($object->status) && $object->status < $object::STATUS_CLOSED && GETPOST('set', 'alpha') != "assign_ticket" && $user->rights->ticket->write) {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if (isset($object->status) && $object->status < $object::STATUS_CLOSED && GETPOST('set', 'alpha') != "assign_ticket" && $permissiontomanage) {
 			print '</td><td class="right"><a class="editfielda" href="'.$url_page_current.'?track_id='.urlencode($object->track_id).'&set=assign_ticket">'.img_edit($langs->trans('Modify'), '').'</a>';
 		}
 		print '</td></tr></table>';
@@ -1084,7 +1108,8 @@ if ($action == 'create' || $action == 'presend') {
 		}
 
 		// Show user list to assignate one if status is "read"
-		if (GETPOST('set', 'alpha') == "assign_ticket" && $object->status < 8 && !$user->socid && $user->rights->ticket->write) {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if (GETPOST('set', 'alpha') == "assign_ticket" && $object->status < 8 && !$user->socid && $permissiontomanage) {
 			print '<form method="post" name="ticket" enctype="multipart/form-data" action="'.$url_page_current.'">';
 			print '<input type="hidden" name="token" value="'.newToken().'">';
 			print '<input type="hidden" name="action" value="assign_user">';
@@ -1101,12 +1126,14 @@ if ($action == 'create' || $action == 'presend') {
 		print '<table class="nobordernopadding centpercent"><tr><td class="nowrap">';
 		print $langs->trans('Progression').'</td><td class="left">';
 		print '</td>';
-		if ($user->rights->ticket->write && $action != 'progression' && isset($object->status) && $object->status < $object::STATUS_CLOSED && !$user->socid) {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if ($permissiontoadd && $action != 'progression' && isset($object->status) && $object->status < $object::STATUS_CLOSED && !$user->socid) {
 			print '<td class="right"><a class="editfielda" href="'.$url_page_current.'?action=progression&token='.newToken().'&track_id='.urlencode($object->track_id).'">'.img_edit($langs->trans('Modify')).'</a></td>';
 		}
 		print '</tr></table>';
 		print '</td><td>';
-		if ($user->rights->ticket->write && $action == 'progression') {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if ($permissiontoadd && $action == 'progression') {
 			print '<form action="'.$url_page_current.'" method="post">';
 			print '<input type="hidden" name="token" value="'.newToken().'">';
 			print '<input type="hidden" name="track_id" value="'.$track_id.'">';
@@ -1168,13 +1195,15 @@ if ($action == 'create' || $action == 'presend') {
 			print '<td class="valignmiddle titlefield">';
 			print '<table class="nobordernopadding centpercent"><tr><td class="titlefield">';
 			print $langs->trans("Categories");
-			if ($user->rights->ticket->write && !in_array($object->status, $closeStatuses) && $action != 'categories' && !$user->socid) {
+			// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+			if ($permissiontoadd && !in_array($object->status, $closeStatuses) && $action != 'categories' && !$user->socid) {
 				print '<td class="right"><a class="editfielda" href="'.$url_page_current.'?action=categories&amp;track_id='.$object->track_id.'">'.img_edit($langs->trans('Modify')).'</a></td>';
 			}
 			print '</table>';
 			print '</td>';
 
-			if ($user->rights->ticket->write && $action == 'categories') {
+			// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+			if ($permissiontoadd && $action == 'categories') {
 				$cate_arbo = $form->select_all_categories(Categorie::TYPE_TICKET, '', 'parent', 64, 0, 1);
 				if (is_array($cate_arbo)) {
 					// Categories
@@ -1216,18 +1245,21 @@ if ($action == 'create' || $action == 'presend') {
 		print $langs->trans('TicketProperties');
 		print '</td>';
 		print '<td>';
-		if (GETPOST('set', 'alpha') == 'properties' && $user->rights->ticket->write) {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if (GETPOST('set', 'alpha') == 'properties' && $permissiontoadd) {
 			print '<input type="submit" class="button small" name="btn_update_ticket_prop" value="'.$langs->trans("Modify").'" />';
 		} else {
 			//    Button to edit Properties
-			if (isset($object->status) && $object->status < $object::STATUS_NEED_MORE_INFO && $user->rights->ticket->write) {
+			// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+			if (isset($object->status) && $object->status < $object::STATUS_NEED_MORE_INFO && $permissiontoadd) {
 				print ' <a class="editfielda" href="card.php?track_id='.$object->track_id.'&set=properties">'.img_edit($langs->trans('Modify')).'</a>';
 			}
 		}
 		print '</td>';
 		print '</tr>';
 
-		if (GETPOST('set', 'alpha') == 'properties' && $user->rights->ticket->write) {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if (GETPOST('set', 'alpha') == 'properties' && $permissiontoadd) {
 			print '<tr>';
 			// Type
 			print '<td class="titlefield">';
@@ -1279,7 +1311,8 @@ if ($action == 'create' || $action == 'presend') {
 
 		// Display navbar with links to change ticket status
 		print '<!-- navbar with status -->';
-		if (!$user->socid && $user->rights->ticket->manage && isset($object->status) && $object->status < $object::STATUS_CLOSED && GETPOST('set') !== 'properties') {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if (!$user->socid && $permissiontomanage && isset($object->status) && $object->status < $object::STATUS_CLOSED && GETPOST('set') !== 'properties') {
 			$actionobject->viewStatusActions($object);
 		}
 
@@ -1433,23 +1466,27 @@ if ($action == 'create' || $action == 'presend') {
 					print dolGetButtonAction('', $langs->trans('TicketAddIntervention'), 'default', DOL_URL_ROOT.'/fichinter/card.php?action=create&token='.newToken().'&socid='. $object->fk_soc.'&origin=ticket_ticket&originid='. $object->id, '');
 				}
 
-				// Close ticket if statut is read
-				if (isset($object->status) && $object->status > 0 && $object->status < Ticket::STATUS_CLOSED && $user->rights->ticket->manage) {
+				// Close ticket if status is read
+				// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+				if (isset($object->status) && $object->status > 0 && $object->status < Ticket::STATUS_CLOSED && $permissiontomanage) {
 					print dolGetButtonAction('', $langs->trans('CloseTicket'), 'default', $_SERVER["PHP_SELF"].'?action=close&token='.newToken().'&track_id='.$object->track_id, '');
 				}
 
 				// Abadon ticket if statut is read
-				if (isset($object->status) && $object->status > 0 && $object->status < Ticket::STATUS_CLOSED && $user->rights->ticket->manage) {
+				// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+				if (isset($object->status) && $object->status > 0 && $object->status < Ticket::STATUS_CLOSED && $permissiontomanage) {
 					print dolGetButtonAction('', $langs->trans('AbandonTicket'), 'default', $_SERVER["PHP_SELF"].'?action=abandon&token='.newToken().'&track_id='.$object->track_id, '');
 				}
 
 				// Re-open ticket
+				// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 				if ($permissiontomanage && !$user->socid && (isset($object->status) && ($object->status == Ticket::STATUS_CLOSED || $object->status == Ticket::STATUS_CANCELED)) && !$user->socid) {
 					print dolGetButtonAction('', $langs->trans('ReOpen'), 'default', $_SERVER["PHP_SELF"].'?action=reopen&token='.newToken().'&track_id='.$object->track_id, '');
 				}
 
 				// Delete ticket
-				if ($user->rights->ticket->delete && !$user->socid) {
+				// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+				if ($permissiontodelete && !$user->socid) {
 					print dolGetButtonAction('', $langs->trans('Delete'), 'delete', $_SERVER["PHP_SELF"].'?action=delete&token='.newToken().'&track_id='.$object->track_id, '');
 				}
 			}

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -842,7 +842,7 @@ if ($action == 'create' || $action == 'presend') {
 			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("AbandonTicket"), $langs->trans("ConfirmAbandonTicket"), "confirm_abandon", '', '', 1);
 		}
 		// Confirmation delete
-		if ($action == 'delete') {
+		if ($action == 'delete' && $permissiontodelete) {
 			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("Delete"), $langs->trans("ConfirmDeleteTicket"), "confirm_delete_ticket", '', '', 1);
 		}
 		// Confirm reopen

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -130,7 +130,10 @@ $result = restrictedArea($user, 'ticket', $object->id);
 $triggermodname = 'TICKET_MODIFY';
 $permissiontoread = $user->hasRight('ticket', 'read');
 $permissiontoadd = $user->hasRight('ticket', 'write');
+$permissiontomanage = $user->hasRight('ticket', 'manage');
 $permissiontodelete = $user->hasRight('ticket', 'delete');
+
+$closeStatuses = [Ticket::STATUS_CLOSED, Ticket::STATUS_CANCELED];
 
 $upload_dir = $conf->ticket->dir_output;
 
@@ -373,7 +376,7 @@ if (empty($reshook)) {
 	}
 
 	// Mark as Read
-	if ($action == "mark_ticket_read" && $permissiontoadd) {
+	if ($action == "mark_ticket_read" && $permissiontomanage) {
 		$object->fetch('', '', GETPOST("track_id", 'alpha'));
 
 		if ($object->markAsRead($user) > 0) {
@@ -388,7 +391,7 @@ if (empty($reshook)) {
 	}
 
 	// Assign to someone
-	if ($action == "assign_user" && GETPOST('btn_assign_user', 'alpha') && $permissiontoadd) {
+	if ($action == "assign_user" && GETPOST('btn_assign_user', 'alpha') && $permissiontomanage) {
 		$object->fetch('', '', GETPOST("track_id", 'alpha'));
 		$useroriginassign = $object->fk_user_assign;
 		$usertoassign = GETPOST('fk_user_assign', 'int');
@@ -465,7 +468,7 @@ if (empty($reshook)) {
 		}
 	}
 
-	if (($action == "confirm_close" || $action == "confirm_abandon") && GETPOST('confirm', 'alpha') == 'yes' && $permissiontoadd) {
+	if (($action == "confirm_close" || $action == "confirm_abandon") && GETPOST('confirm', 'alpha') == 'yes' && $permissiontomanage) {
 		$object->fetch(GETPOST('id', 'int'), '', GETPOST('track_id', 'alpha'));
 
 		if ($object->close($user, ($action == "confirm_abandon" ? 1 : 0))) {
@@ -601,7 +604,7 @@ if (empty($reshook)) {
 			header("Location: ".$url);
 			exit();
 		}
-	} elseif ($action == "set_message" && $user->rights->ticket->manage) {
+	} elseif ($action == "set_message" && $user->rights->ticket->write) {
 		if (!GETPOST('cancel')) {
 			$object->fetch('', '', GETPOST('track_id', 'alpha'));
 			$oldvalue_message = $object->message;
@@ -624,7 +627,7 @@ if (empty($reshook)) {
 		}
 
 		$action = 'view';
-	} elseif ($action == 'confirm_set_status' && $permissiontoadd && !GETPOST('cancel')) {
+	} elseif ($action == 'confirm_set_status' && $permissiontomanage && !GETPOST('cancel')) {
 		// Reopen ticket
 		if ($object->fetch(GETPOST('id', 'int'), GETPOST('track_id', 'alpha')) >= 0) {
 			$new_status = GETPOST('new_status', 'int');
@@ -810,7 +813,7 @@ if ($action == 'create' || $action == 'presend') {
 		}
 
 		// Confirmation close
-		if ($action == 'close') {
+		if ($action == 'close' && $permissiontomanage) {
 			$thirdparty_contacts = $object->getInfosTicketExternalContact();
 			$contacts_select = array(
 				'-2' => $langs->trans('TicketNotifyAllTiersAtClose'),
@@ -835,7 +838,7 @@ if ($action == 'create' || $action == 'presend') {
 			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("CloseATicket"), $langs->trans("ConfirmCloseAticket"), "confirm_close", $formquestion, '', 1);
 		}
 		// Confirmation abandon
-		if ($action == 'abandon') {
+		if ($action == 'abandon' && $permissiontomanage) {
 			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("AbandonTicket"), $langs->trans("ConfirmAbandonTicket"), "confirm_abandon", '', '', 1);
 		}
 		// Confirmation delete
@@ -843,7 +846,7 @@ if ($action == 'create' || $action == 'presend') {
 			print $form->formconfirm($url_page_current."?track_id=".$object->track_id, $langs->trans("Delete"), $langs->trans("ConfirmDeleteTicket"), "confirm_delete_ticket", '', '', 1);
 		}
 		// Confirm reopen
-		if ($action == 'reopen') {
+		if ($action == 'reopen' && $permissiontomanage) {
 			print $form->formconfirm($url_page_current.'?track_id='.$object->track_id, $langs->trans('ReOpen'), $langs->trans('ConfirmReOpenTicket'), 'confirm_reopen', '', '', 1);
 		}
 		// Confirmation status change
@@ -1022,7 +1025,7 @@ if ($action == 'create' || $action == 'presend') {
 
 		// Subject
 		print '<tr><td>';
-		print $form->editfieldkey("Subject", 'subject', $object->subject, $object, $user->rights->ticket->write && !$user->socid, 'string');
+		print $form->editfieldkey("Subject", 'subject', $object->subject, $object, $user->rights->ticket->write && !in_array($object->status, $closeStatuses) && !$user->socid, 'string');
 		print '</td><td>';
 		print $form->editfieldval("Subject", 'subject', $object->subject, $object, $user->rights->ticket->write && !$user->socid, 'string');
 		print '</td></tr>';
@@ -1070,7 +1073,7 @@ if ($action == 'create' || $action == 'presend') {
 		print '<tr><td>';
 		print '<table class="nobordernopadding" width="100%"><tr><td class="nowrap">';
 		print $langs->trans("AssignedTo");
-		if (isset($object->status) && $object->status < $object::STATUS_CLOSED && GETPOST('set', 'alpha') != "assign_ticket" && $user->rights->ticket->manage) {
+		if (isset($object->status) && $object->status < $object::STATUS_CLOSED && GETPOST('set', 'alpha') != "assign_ticket" && $user->rights->ticket->write) {
 			print '</td><td class="right"><a class="editfielda" href="'.$url_page_current.'?track_id='.urlencode($object->track_id).'&set=assign_ticket">'.img_edit($langs->trans('Modify'), '').'</a>';
 		}
 		print '</td></tr></table>';
@@ -1098,7 +1101,7 @@ if ($action == 'create' || $action == 'presend') {
 		print '<table class="nobordernopadding centpercent"><tr><td class="nowrap">';
 		print $langs->trans('Progression').'</td><td class="left">';
 		print '</td>';
-		if ($action != 'progression' && isset($object->status) && $object->status < $object::STATUS_CLOSED && !$user->socid) {
+		if ($user->rights->ticket->write && $action != 'progression' && isset($object->status) && $object->status < $object::STATUS_CLOSED && !$user->socid) {
 			print '<td class="right"><a class="editfielda" href="'.$url_page_current.'?action=progression&token='.newToken().'&track_id='.urlencode($object->track_id).'">'.img_edit($langs->trans('Modify')).'</a></td>';
 		}
 		print '</tr></table>';
@@ -1165,7 +1168,7 @@ if ($action == 'create' || $action == 'presend') {
 			print '<td class="valignmiddle titlefield">';
 			print '<table class="nobordernopadding centpercent"><tr><td class="titlefield">';
 			print $langs->trans("Categories");
-			if ($action != 'categories' && !$user->socid) {
+			if ($user->rights->ticket->write && !in_array($object->status, $closeStatuses) && $action != 'categories' && !$user->socid) {
 				print '<td class="right"><a class="editfielda" href="'.$url_page_current.'?action=categories&amp;track_id='.$object->track_id.'">'.img_edit($langs->trans('Modify')).'</a></td>';
 			}
 			print '</table>';
@@ -1276,7 +1279,7 @@ if ($action == 'create' || $action == 'presend') {
 
 		// Display navbar with links to change ticket status
 		print '<!-- navbar with status -->';
-		if (!$user->socid && $user->rights->ticket->write && isset($object->status) && $object->status < $object::STATUS_CLOSED && GETPOST('set') !== 'properties') {
+		if (!$user->socid && $user->rights->ticket->manage && isset($object->status) && $object->status < $object::STATUS_CLOSED && GETPOST('set') !== 'properties') {
 			$actionobject->viewStatusActions($object);
 		}
 
@@ -1431,17 +1434,17 @@ if ($action == 'create' || $action == 'presend') {
 				}
 
 				// Close ticket if statut is read
-				if (isset($object->status) && $object->status > 0 && $object->status < Ticket::STATUS_CLOSED && $user->rights->ticket->write) {
+				if (isset($object->status) && $object->status > 0 && $object->status < Ticket::STATUS_CLOSED && $user->rights->ticket->manage) {
 					print dolGetButtonAction('', $langs->trans('CloseTicket'), 'default', $_SERVER["PHP_SELF"].'?action=close&token='.newToken().'&track_id='.$object->track_id, '');
 				}
 
 				// Abadon ticket if statut is read
-				if (isset($object->status) && $object->status > 0 && $object->status < Ticket::STATUS_CLOSED && $user->rights->ticket->write) {
+				if (isset($object->status) && $object->status > 0 && $object->status < Ticket::STATUS_CLOSED && $user->rights->ticket->manage) {
 					print dolGetButtonAction('', $langs->trans('AbandonTicket'), 'default', $_SERVER["PHP_SELF"].'?action=abandon&token='.newToken().'&track_id='.$object->track_id, '');
 				}
 
 				// Re-open ticket
-				if (!$user->socid && (isset($object->status) && ($object->status == Ticket::STATUS_CLOSED || $object->status == Ticket::STATUS_CANCELED)) && !$user->socid) {
+				if ($permissiontomanage && !$user->socid && (isset($object->status) && ($object->status == Ticket::STATUS_CLOSED || $object->status == Ticket::STATUS_CANCELED)) && !$user->socid) {
 					print dolGetButtonAction('', $langs->trans('ReOpen'), 'default', $_SERVER["PHP_SELF"].'?action=reopen&token='.newToken().'&track_id='.$object->track_id, '');
 				}
 

--- a/htdocs/ticket/card.php
+++ b/htdocs/ticket/card.php
@@ -134,6 +134,7 @@ $permissiontoadd = $user->hasRight('ticket', 'write');
 $permissiontomanage = $user->hasRight('ticket', 'manage');
 $permissiontodelete = $user->hasRight('ticket', 'delete');
 
+// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
 $closeStatuses = [Ticket::STATUS_CLOSED, Ticket::STATUS_CANCELED];
 
 $upload_dir = $conf->ticket->dir_output;

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -182,10 +182,15 @@ class ActionsTicket
 	{
 		global $conf, $langs;
 
+		// BACKPORT v24 START - https://github.com/Dolibarr/dolibarr/pull/37490
 		$closeStatuses = [Ticket::STATUS_CLOSED, Ticket::STATUS_CANCELED];
 
+		$permissiontoadd = $user->hasRight('ticket', 'write');
+		// BACKPORT v24 END - https://github.com/Dolibarr/dolibarr/pull/37490
+
 		print '<!-- initial message of ticket -->'."\n";
-		if (!empty($user->rights->ticket->write) && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if ($permissiontoadd && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
 			// MESSAGE
 
 			print '<form action="'.$_SERVER['PHP_SELF'].'" method="post">';
@@ -201,14 +206,16 @@ class ActionsTicket
 		print '<tr class="liste_titre trforfield"><td class="nowrap titlefield">';
 		print $langs->trans("InitialMessage");
 		print '</td><td>';
-		if ($user->hasRight("ticket", "write") && !in_array($object->status, $closeStatuses)) {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if ($permissiontoadd && !in_array($object->status, $closeStatuses)) {
 			print '<a class="editfielda" href="'.$_SERVER['PHP_SELF'].'?action=edit_message_init&token='.newToken().'&track_id='.$object->track_id.'">'.img_edit($langs->trans('Modify')).'</a>';
 		}
 		print '</td></tr>';
 
 		print '<tr>';
 		print '<td colspan="2">';
-		if ($user->hasRight('ticket', 'write') && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if ($permissiontoadd && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
 			// MESSAGE
 			$msg = GETPOSTISSET('message_initial') ? GETPOST('message_initial', 'restricthtml') : $object->message;
 			include_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
@@ -236,7 +243,8 @@ class ActionsTicket
 
 			//print '<div>' . $object->message . '</div>';
 		}
-		if (!empty($user->rights->ticket->write) && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if ($permissiontoadd && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
 			print '<div class="center">';
 			print ' <input type="submit" class="button button-edit" value="'.$langs->trans('Modify').'">';
 			print ' <input type="submit" class="button button-cancel" name="cancel" value="'.$langs->trans("Cancel").'">';
@@ -247,7 +255,8 @@ class ActionsTicket
 		print '</table>';
 		print '</div>';
 
-		if (!empty($user->rights->ticket->write) && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
+		// BACKPORT v24 - https://github.com/Dolibarr/dolibarr/pull/37490
+		if ($permissiontoadd && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
 			// MESSAGE
 			print '</form>';
 		}

--- a/htdocs/ticket/class/actions_ticket.class.php
+++ b/htdocs/ticket/class/actions_ticket.class.php
@@ -182,8 +182,10 @@ class ActionsTicket
 	{
 		global $conf, $langs;
 
+		$closeStatuses = [Ticket::STATUS_CLOSED, Ticket::STATUS_CANCELED];
+
 		print '<!-- initial message of ticket -->'."\n";
-		if (!empty($user->rights->ticket->manage) && $action == 'edit_message_init') {
+		if (!empty($user->rights->ticket->write) && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
 			// MESSAGE
 
 			print '<form action="'.$_SERVER['PHP_SELF'].'" method="post">';
@@ -199,14 +201,14 @@ class ActionsTicket
 		print '<tr class="liste_titre trforfield"><td class="nowrap titlefield">';
 		print $langs->trans("InitialMessage");
 		print '</td><td>';
-		if ($user->hasRight("ticket", "manage")) {
+		if ($user->hasRight("ticket", "write") && !in_array($object->status, $closeStatuses)) {
 			print '<a class="editfielda" href="'.$_SERVER['PHP_SELF'].'?action=edit_message_init&token='.newToken().'&track_id='.$object->track_id.'">'.img_edit($langs->trans('Modify')).'</a>';
 		}
 		print '</td></tr>';
 
 		print '<tr>';
 		print '<td colspan="2">';
-		if ($user->hasRight('ticket', 'manage') && $action == 'edit_message_init') {
+		if ($user->hasRight('ticket', 'write') && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
 			// MESSAGE
 			$msg = GETPOSTISSET('message_initial') ? GETPOST('message_initial', 'restricthtml') : $object->message;
 			include_once DOL_DOCUMENT_ROOT.'/core/class/doleditor.class.php';
@@ -234,7 +236,7 @@ class ActionsTicket
 
 			//print '<div>' . $object->message . '</div>';
 		}
-		if (!empty($user->rights->ticket->manage) && $action == 'edit_message_init') {
+		if (!empty($user->rights->ticket->write) && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
 			print '<div class="center">';
 			print ' <input type="submit" class="button button-edit" value="'.$langs->trans('Modify').'">';
 			print ' <input type="submit" class="button button-cancel" name="cancel" value="'.$langs->trans("Cancel").'">';
@@ -245,7 +247,7 @@ class ActionsTicket
 		print '</table>';
 		print '</div>';
 
-		if (!empty($user->rights->ticket->manage) && $action == 'edit_message_init') {
+		if (!empty($user->rights->ticket->write) && !in_array($object->status, $closeStatuses) && $action == 'edit_message_init') {
 			// MESSAGE
 			print '</form>';
 		}


### PR DESCRIPTION
Fix ticket permissions. Currently, ticket permissions lack consistency. For instance, editing the "initial message" field improperly requires **Manage** rights instead of **Write** rights.

Here is the breakdown of permissions:
- **Read**: Allows users to **view** all ticket information.
- **Write**: Allows users to **edit** all ticket information, except for fields that affect the ticket status (including reopening tickets).
- **Delete**: Allows users to permanently **delete** tickets.
- **Manage**: Allows users to **change the ticket status** (including reopening tickets).