### PR TITLE
FIX : DA028159 - BACKPORT - Introduction des Pages PDF pour les signatures. Pour éviter que la signature en ligne n'atterrisse pas sur une mauvaise page du PDF

### DIFF
--- a/ChangeLogWeneos.md
+++ b/ChangeLogWeneos.md
@@ -9,3 +9,8 @@ NEW : Backport d'un développement proposé dans le standard en develop (22.0)
 FIX :  La fusion de deux tiers échouait avec une erreur de contrainte FK sur llx_prospectingmap_coordinate
 /home/client/weneos/dolibarr/htdocs/societe/class/societe.class.php => L5141 - 5150
 /home/client/weneos/dolibarr/htdocs/societe/card.php => L368 - 369
+
+FIX : DA028159 - Introduction des Pages PDF pour les signatures (htdocs/core/ajax/onlineSign.php).
+Pour éviter que la signature en ligne n'atterrisse pas sur une mauvaise page. 
+A supp en V22.
+

--- a/htdocs/core/ajax/onlineSign.php
+++ b/htdocs/core/ajax/onlineSign.php
@@ -66,6 +66,8 @@ $response = "";
 
 $type = $mode;
 
+$hookmanager->initHooks(array('onlinesign'));
+
 // Security check
 $securekeyseed = '';
 if ($type == 'proposal') {
@@ -137,54 +139,85 @@ if ($action == "importSignature") {
 					$sourcefile = $upload_dir.$ref.".pdf";
 
 					if (dol_is_file($sourcefile)) {
-						// We build the new PDF
-						$pdf = pdf_getInstance();
-						if (class_exists('TCPDF')) {
-							$pdf->setPrintHeader(false);
-							$pdf->setPrintFooter(false);
-						}
-						$pdf->SetFont(pdf_getPDFFont($langs));
-
-						if (getDolGlobalString('MAIN_DISABLE_PDF_COMPRESSION')) {
-							$pdf->SetCompression(false);
+						// Hook AddSignature (backported from upstream develop): lets a module
+						// fully take over the signature PDF construction. Return >0 to skip the default flow.
+						$parameters = array('sourcefile' => $sourcefile, 'newpdffilename' => $newpdffilename);
+						$reshook = $hookmanager->executeHooks('AddSignature', $parameters, $object, $action);
+						if ($reshook < 0) {
+							setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
 						}
 
-						//$pdf->Open();
-						$pagecount = $pdf->setSourceFile($sourcefile);		// original PDF
-
-						$s = array(); 	// Array with size of each page. Exemple array(w'=>210, 'h'=>297);
-						for ($i=1; $i<($pagecount+1); $i++) {
-							try {
-								$tppl = $pdf->importPage($i);
-								$s = $pdf->getTemplatesize($tppl);
-								$pdf->AddPage($s['h'] > $s['w'] ? 'P' : 'L');
-								$pdf->useTemplate($tppl);
-							} catch (Exception $e) {
-								dol_syslog("Error when manipulating the PDF ".$sourcefile." by onlineSign: ".$e->getMessage(), LOG_ERR);
-								$response = $e->getMessage();
-								$error++;
+						if (empty($reshook)) {
+							// We build the new PDF
+							$pdf = pdf_getInstance();
+							if (class_exists('TCPDF')) {
+								$pdf->setPrintHeader(false);
+								$pdf->setPrintFooter(false);
 							}
+							$pdf->SetFont(pdf_getPDFFont($langs));
+
+							if (getDolGlobalString('MAIN_DISABLE_PDF_COMPRESSION')) {
+								$pdf->SetCompression(false);
+							}
+
+							//$pdf->Open();
+							$pagecount = $pdf->setSourceFile($sourcefile);		// original PDF
+
+							$s = array(); 	// Array with size of each page. Exemple array(w'=>210, 'h'=>297);
+							for ($i=1; $i<($pagecount+1); $i++) {
+								try {
+									$tppl = $pdf->importPage($i);
+									$s = $pdf->getTemplatesize($tppl);
+									$pdf->AddPage($s['h'] > $s['w'] ? 'P' : 'L');
+									$pdf->useTemplate($tppl);
+								} catch (Exception $e) {
+									dol_syslog("Error when manipulating the PDF ".$sourcefile." by onlineSign: ".$e->getMessage(), LOG_ERR);
+									$response = $e->getMessage();
+									$error++;
+								}
+							}
+
+							// Backport from upstream develop:
+							// PROPAL_SIGNATURE_ON_SPECIFIC_PAGE: positive=absolute page, negative=count from end.
+							// PROPAL_SIGNATURE_ON_ALL_PAGES: stamp every page. Default fallback: last imported page (legacy).
+							$propalsignonspecificpage = getDolGlobalInt("PROPAL_SIGNATURE_ON_SPECIFIC_PAGE");
+							if ($propalsignonspecificpage < 0) {
+								$propalsignonspecificpage = $pagecount - abs($propalsignonspecificpage);
+							}
+
+							// A signature image file is 720 x 180 (ratio 1/4) but we use only the size into PDF
+							$xforimgstart = getDolGlobalString("PROPAL_SIGNATURE_XFORIMGSTART") ? getDolGlobalString("PROPAL_SIGNATURE_XFORIMGSTART") : (empty($s['w']) ? 120 : round($s['w'] / 2) + 15);
+							$yforimgstart = getDolGlobalString("PROPAL_SIGNATURE_YFORIMGSTART") ? getDolGlobalString("PROPAL_SIGNATURE_YFORIMGSTART") : (empty($s['h']) ? 240 : $s['h'] - 60);
+							$wforimg = getDolGlobalString("PROPAL_SIGNATURE_WFORIMG") ? getDolGlobalString("PROPAL_SIGNATURE_WFORIMG") : $s['w'] - 20 - $xforimgstart;
+
+							$pagesToSign = array();
+							if (getDolGlobalString("PROPAL_SIGNATURE_ON_ALL_PAGES")) {
+								for ($p = 1; $p <= $pagecount; $p++) {
+									$pagesToSign[] = $p;
+								}
+							} elseif ($propalsignonspecificpage > 0 && $propalsignonspecificpage <= $pagecount) {
+								$pagesToSign[] = $propalsignonspecificpage;
+							} else {
+								$pagesToSign[] = $pagecount;
+							}
+
+							foreach ($pagesToSign as $targetpage) {
+								$pdf->setPage($targetpage);
+								$pdf->SetXY($xforimgstart, $yforimgstart + round($wforimg / 4) - 4);
+								$pdf->SetFont($default_font, '', $default_font_size - 1);
+								$pdf->MultiCell($wforimg, 4, $langs->trans("DateSigning").': '.dol_print_date(dol_now(), "daytext", false, $langs, true), 0, 'L');
+								$pdf->SetXY($xforimgstart, $yforimgstart + round($wforimg / 4));
+								$pdf->MultiCell($wforimg, 4, $langs->trans("Lastname").': '.$online_sign_name, 0, 'L');
+
+								$pdf->Image($upload_dir.$filename, $xforimgstart, $yforimgstart, $wforimg, round($wforimg / 4));
+							}
+
+							//$pdf->Close();
+							$pdf->Output($newpdffilename, "F");
+
+							// Index the new file and update the last_main_doc property of object.
+							$object->indexFile($newpdffilename, 1);
 						}
-
-						// A signature image file is 720 x 180 (ratio 1/4) but we use only the size into PDF
-						// TODO Get position of box from PDF template
-						$xforimgstart = (empty($s['w']) ? 120 : round($s['w'] / 2) + 15);
-						$yforimgstart = (empty($s['h']) ? 240 : $s['h'] - 60);
-						$wforimg = $s['w'] - 20 - $xforimgstart;
-
-						$pdf->SetXY($xforimgstart, $yforimgstart + round($wforimg / 4) - 4);
-						$pdf->SetFont($default_font, '', $default_font_size - 1);
-						$pdf->MultiCell($wforimg, 4, $langs->trans("DateSigning").': '.dol_print_date(dol_now(), "daytext", false, $langs, true), 0, 'L');
-						$pdf->SetXY($xforimgstart, $yforimgstart + round($wforimg / 4));
-						$pdf->MultiCell($wforimg, 4, $langs->trans("Lastname").': '.$online_sign_name, 0, 'L');
-
-						$pdf->Image($upload_dir.$filename, $xforimgstart, $yforimgstart, $wforimg, round($wforimg / 4));
-
-						//$pdf->Close();
-						$pdf->Output($newpdffilename, "F");
-
-						// Index the new file and update the last_main_doc property of object.
-						$object->indexFile($newpdffilename, 1);
 					}
 				} elseif (preg_match('/\.odt/i', $last_main_doc_file)) {
 					// Adding signature on .ODT not yet supported


### PR DESCRIPTION
FIX : DA028159 - Introduction des Pages PDF pour les signatures (htdocs/core/ajax/onlineSign.php). Pour éviter que la signature en ligne n'atterrisse pas sur une mauvaise page. 