### PR TITLE
FIX: enforce product price_min when editing an order / proposal / invoice line

### DIFF
--- a/ChangeLog_Alphadiab
+++ b/ChangeLog_Alphadiab
@@ -7,3 +7,4 @@
 - backport issue on categorie : Create a new instance for each object to avoid reference issues
 - Fix invoice partial payment flow to reload page after escompte validation
 - Fix display bank account **17/12/2025**
+- Fix order line edit: enforce product price_min on updateline (the editline form does not POST productid, which caused the min-price check to be skipped) **27/05/2026**

--- a/ChangeLog_Alphadiab
+++ b/ChangeLog_Alphadiab
@@ -8,3 +8,5 @@
 - Fix invoice partial payment flow to reload page after escompte validation
 - Fix display bank account **17/12/2025**
 - Fix order line edit: enforce product price_min on updateline (the editline form does not POST productid, which caused the min-price check to be skipped) **27/05/2026**
+- Fix proposal line edit: enforce product price_min on updateline (same productid-missing bug as for orders) **27/05/2026**
+- Fix invoice line edit: enforce product price_min on updateline (same productid-missing + price_base_type-not-initialized bugs as for orders) **27/05/2026**

--- a/htdocs/comm/propal/card.php
+++ b/htdocs/comm/propal/card.php
@@ -1612,6 +1612,15 @@ if (empty($reshook)) {
 
 		// Check minimum price
 		$productid = GETPOSTINT('productid');
+		// FIX ATM (price-min on editline): le formulaire d'édition de ligne envoie lineid mais pas productid.
+		// Sans ce fallback, tout le bloc de vérification du prix minimum ci-dessous est sauté,
+		// permettant à un utilisateur sans la permission 'produit > ignore_price_min_advance'
+		// de modifier le PU sous le price_min. Récupère fk_product depuis la ligne postée.
+		if (empty($productid) && GETPOSTINT('lineid')) {
+			foreach ($object->lines as $oldl) {
+				if ((int) $oldl->id === GETPOSTINT('lineid')) { $productid = (int) $oldl->fk_product; break; }
+			}
+		}
 		if (!empty($productid)) {
 			$product = new Product($db);
 			$res = $product->fetch($productid);

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1287,6 +1287,14 @@ if (empty($reshook)) {
 
 		$remise_percent = GETPOST('remise_percent') != '' ? price2num(GETPOST('remise_percent'), '', 2) : 0;
 
+		// FIX ATM (price-min on editline): $price_base_type n'est jamais initialisé dans le bloc updateline
+		// avant le check ci-dessous (il reste à null défini ligne 118), donc `$price_base_type == 'HT'`
+		// échouait silencieusement et le check était sauté. On initialise ici comme ligne 1370 plus bas.
+		$price_base_type = 'HT';
+		if (empty($pu_ht) && !empty($pu_ttc)) {
+			$price_base_type = 'TTC';
+		}
+
 		// Check minimum price
 		$productid = GETPOSTINT('productid');
 		// FIX ATM (price-min on editline): le formulaire d'édition de ligne envoie lineid mais pas productid.

--- a/htdocs/commande/card.php
+++ b/htdocs/commande/card.php
@@ -1289,6 +1289,15 @@ if (empty($reshook)) {
 
 		// Check minimum price
 		$productid = GETPOSTINT('productid');
+		// FIX ATM (price-min on editline): le formulaire d'édition de ligne envoie lineid mais pas productid.
+		// Sans ce fallback, tout le bloc de vérification du prix minimum ci-dessous est sauté,
+		// permettant à un utilisateur sans la permission 'produit > ignore_price_min_advance'
+		// de modifier le PU sous le price_min. Récupère fk_product depuis la ligne posté.
+		if (empty($productid) && GETPOSTINT('lineid')) {
+			foreach ($object->lines as $oldl) {
+				if ((int) $oldl->id === GETPOSTINT('lineid')) { $productid = (int) $oldl->fk_product; break; }
+			}
+		}
 		if (!empty($productid)) {
 			$product = new Product($db);
 			$product->fetch($productid);

--- a/htdocs/compta/facture/card.php
+++ b/htdocs/compta/facture/card.php
@@ -2740,8 +2740,25 @@ if (empty($reshook)) {
 
 		$remise_percent = price2num(GETPOST('remise_percent'), '', 2);
 
+		// FIX ATM (price-min on editline): $price_base_type n'est jamais initialisé dans le bloc updateline
+		// avant le check ci-dessous (il reste à '' défini ligne 137), donc `$price_base_type == 'HT'`
+		// échouait silencieusement et le check était sauté. On initialise ici comme ligne 2838 plus bas.
+		$price_base_type = 'HT';
+		if (empty($pu_ht) && !empty($pu_ttc)) {
+			$price_base_type = 'TTC';
+		}
+
 		// Check minimum price
 		$productid = GETPOSTINT('productid');
+		// FIX ATM (price-min on editline): le formulaire d'édition de ligne envoie lineid mais pas productid.
+		// Sans ce fallback, tout le bloc de vérification du prix minimum ci-dessous est sauté,
+		// permettant à un utilisateur sans la permission 'produit > ignore_price_min_advance'
+		// de modifier le PU sous le price_min. Récupère fk_product depuis la ligne postée.
+		if (empty($productid) && GETPOSTINT('lineid')) {
+			foreach ($object->lines as $oldl) {
+				if ((int) $oldl->id === GETPOSTINT('lineid')) { $productid = (int) $oldl->fk_product; break; }
+			}
+		}
 		if (!empty($productid)) {
 			$product = new Product($db);
 			$product->fetch($productid);


### PR DESCRIPTION
## Summary
Same security bug present in 3 places: `htdocs/commande/card.php`, `htdocs/comm/propal/card.php`, `htdocs/compta/facture/card.php`. A salesperson **without** the `produit > ignore_price_min_advance` permission could **edit** an existing line's unit price below the product's `price_min`. Adding a new line below the min was correctly blocked — only the edit path was bypassed.

## Root cause(s)

Two cumulated bugs in the `updateline` action block of each `card.php`:

### Bug #1 — `$productid` never posted by the editline form
The entire min-price verification block is guarded by `if (!empty($productid))` where `$productid = GETPOSTINT('productid')`. The editline form posts `lineid` but **not** `productid`, so the whole check (~30 lines) is silently skipped.
- Affects: `commande`, `propal`, `facture`

### Bug #2 — `$price_base_type` never initialized before the check
The check tests `$price_base_type == 'HT'` (or 'TTC'). In `commande/card.php` and `compta/facture/card.php`, `$price_base_type` keeps its default `null` / `''` from the global init (line 118 / 137) until line 1370 / 2838 — **after** the check. So `== 'HT'` is always false even when `$productid` is correctly resolved.
- Affects: `commande`, `facture` (not `propal` which initializes correctly at line 1607)

## Fix

For each affected file, in the `elseif ($action == 'updateline' …)` block:

1. **Init `$price_base_type` from `$pu_ht` / `$pu_ttc` just before the check** (mirrors the existing assignment further down). Only for `commande` and `facture`.
2. **Recover `fk_product` from the loaded `$object->lines` when `productid` is empty** (`lineid` is always posted by the editline form). For all three files.

The existing check block is otherwise untouched.

## Reproduced on
Dolibarr 21.0 (branch `21.0_alphadiab`). Confirmed live on order 2026169607 / user `FJ` / product `DBF434K` (`price_min` 5.17 €): the user could set `subprice` to 0/2/3 € before the fix; after the fix the same edit is rejected with `CantBeLessThanMinPrice`.

## Test plan
- [x] Log in as a non-admin user **without** `produit > ignore_price_min_advance`.
- [x] Open a draft order, add a product line with PU ≥ price_min → must save.
- [x] Edit that line and set PU < price_min → must be rejected with "Le prix ne peut être inférieur au prix minimum".
- [x] Same for TTC base type → rejected with TTC error message.
- [x] Repeat the edit scenario on a draft proposal → must be rejected.
- [x] Repeat the edit scenario on a draft STANDARD invoice → must be rejected.
- [x] On a STANDARD invoice, log in as a user **with** the `ignore_price_min_advance` right → edit must be allowed (no regression).
- [x] On deposit/situation/credit-note invoices, the check stays disabled (core-intentional, untouched).

