### PR TITLE
Fix/support/da028241/situation ratio denominator

### DIFF
--- a/ChangeLog_loukta
+++ b/ChangeLog_loukta
@@ -1,4 +1,5 @@
 ***** ChangeLog for loukta *****
+- FIX DA028241 - FactureLigne::getSituationRatio() - wrong denominator (100 instead of situation_percent) in mode 1 caused incorrect line amounts in situation invoice PDFs. - *18/06/2026*
 - FIX DA027405 - merging PR Dolibarr#36503 in advance for Loukta: PDF for situation invoices uses legacy calculations
  (cumulative) instead of the new algorithm (delta). Once the community PR is merged, this specific code can be discarded
  and replaced with the community equivalent. - *03/12/2025*

--- a/htdocs/compta/facture/class/factureligne.class.php
+++ b/htdocs/compta/facture/class/factureligne.class.php
@@ -996,12 +996,15 @@ class FactureLigne extends CommonInvoiceLine
 	public function getSituationRatio()
 	{
 		if (getDolGlobalInt('INVOICE_USE_SITUATION') === 1) {
-			// in legacy mode, the situation invoice line stores the (cumulative) state of the
-			// cycle at the current situation. To get the delta, we need to subtract the
-			// state at the previous situation (if applicable).
+			// Legacy mode: line stores the cumulative state (e.g. 70%). To get the delta ratio
+			// we divide by situation_percent, not by 100 — because total_ht is already scaled
+			// by situation_percent/100, so the multiplier must cancel that factor out.
+			if (empty($this->situation_percent)) {
+				return 0;
+			}
 			$prevProgress = $this->get_prev_progress($this->fk_facture);
 
-			return ($this->situation_percent - $prevProgress) / 100;
+			return ($this->situation_percent - $prevProgress) / $this->situation_percent;
 		}
 		// new mode (INVOICE_USE_SITUATION == 2):
 		// no ratio needed (data stored on line is already a delta)


### PR DESCRIPTION
https://doliboard.atm-consulting.fr/ticket/messaging.php?track_id=548mpbb2cau5wra2


## Contexte

DA028241 — Facture de situation FA2605-0251 (client Loukta) : montants de lignes incorrects dans le PDF en mode 1 cumulatif (`INVOICE_USE_SITUATION = 1`).

---

## Commit

### FIX : DA028241 - FactureLigne::getSituationRatio() - wrong denominator in mode 1 situation invoices

Dans `getSituationRatio()` (`factureligne.class.php`), le calcul du ratio de la situation courante en mode 1 utilisait `100` comme dénominateur au lieu de `situation_percent`.

Formule incorrecte :
```php
return ($this->situation_percent - $prev_progress) / 100;
```

Formule corrigée :
```php
return ($this->situation_percent - $prev_progress) / $this->situation_percent;
```

Résultat de la régression : `pdf_getlinetotalexcltax()` retournait un montant HT de ligne erroné (sous-évalué), provoquant des totaux incohérents dans le PDF de la facture de situation.

---

## Test plan

- [ ] Facture de situation mode 1 : montant HT de chaque ligne = valeur correcte dans le PDF
- [ ] Facture de situation mode 1 : total HT / TVA / TTC du PDF cohérents avec les totaux de l'en-tête facture
- [ ] Facture de situation mode 2 : pas de régression (getSituationRatio retourne 1 en mode 2, non impacté)
