### PR TITLE
DOC : DA028241 - getSituationRatio() core-patch debt + credit-note scope limit (suivi #748)

### DIFF
--- a/ChangeLog_loukta
+++ b/ChangeLog_loukta
@@ -1,5 +1,6 @@
 ***** ChangeLog for loukta *****
 - FIX DA028241 - FactureLigne::getSituationRatio() - wrong denominator (100 instead of situation_percent) in mode 1 caused incorrect line amounts in situation invoice PDFs. - *18/06/2026*
+- NOTE DA028241 - getSituationRatio() is a LOCAL CORE PATCH (factureligne.class.php + core/lib/pdf.lib.php), overwritten on each Dolibarr core upgrade; to be dropped once upstream PR Dolibarr#36503 lands. Scope is the mode-1 denominator only - credit notes in a situation cycle are NOT handled (get_prev_progress() still adds credit-note percents), so such a cycle may still yield a wrong/negative delta. - *19/06/2026*
 - FIX DA027405 - merging PR Dolibarr#36503 in advance for Loukta: PDF for situation invoices uses legacy calculations
  (cumulative) instead of the new algorithm (delta). Once the community PR is merged, this specific code can be discarded
  and replaced with the community equivalent. - *03/12/2025*

--- a/htdocs/compta/facture/class/factureligne.class.php
+++ b/htdocs/compta/facture/class/factureligne.class.php
@@ -991,6 +991,17 @@ class FactureLigne extends CommonInvoiceLine
 	 * New mode = the values on the line already represent the delta between the previous
 	 * state and the current state, so we don't need a conversion (we return 1).
 	 *
+	 * LOCAL CORE PATCH (technical debt) — DA027405 / DA028241:
+	 * This method and its consumers in core/lib/pdf.lib.php are a Loukta-local backport of
+	 * upstream PR Dolibarr#36503. They modify core files and WILL be overwritten on the next
+	 * Dolibarr core upgrade — re-apply, or preferably drop them, once #36503 is merged upstream.
+	 *
+	 * SCOPE LIMITATION — DA028241:
+	 * This fix only corrects the mode-1 denominator. It does NOT handle credit notes: in
+	 * get_prev_progress() the credit-note percents are still ADDED (+=) to the previous
+	 * progress, so a situation cycle that contains a credit note can still produce a wrong
+	 * (possibly negative) delta here. Credit-note progression is tracked separately.
+	 *
 	 * @return int
 	 */
 	public function getSituationRatio()

--- a/htdocs/compta/facture/class/factureligne.class.php
+++ b/htdocs/compta/facture/class/factureligne.class.php
@@ -980,6 +980,7 @@ class FactureLigne extends CommonInvoiceLine
 		}
 	}
 
+	// LOUKTA DA028241 - START
 	/**
 	 * Determines if we are using situation invoices.
 	 * If so, determines if we are using the new mode (2) or legacy mode (1).
@@ -1022,4 +1023,5 @@ class FactureLigne extends CommonInvoiceLine
 		// or not a situation invoice: no ratio needed either
 		return 1;
 	}
+	// LOUKTA DA028241 - END
 }


### PR DESCRIPTION
Suivi documentaire de la PR #748 (déjà mergée). **Documentation seule, aucune logique modifiée.**

Formalise deux points relevés en revue de #748 :

- **Dette core (O3)** : `FactureLigne::getSituationRatio()` + ses consommateurs dans `core/lib/pdf.lib.php` sont un patch **core local** (backport de l'upstream PR Dolibarr#36503, cf. DA027405). Ils seront **écrasés à chaque montée de version du core** → à reporter, ou de préférence à supprimer une fois #36503 mergé en amont.
- **Limite de périmètre (O4)** : le fix corrige **uniquement le dénominateur en mode 1**. Il **ne gère pas les avoirs** : `get_prev_progress()` additionne encore (`+=`) les pourcentages des avoirs, donc un cycle de situation **contenant un avoir** peut toujours produire un delta faux (voire négatif).

Modifs : docblock de `getSituationRatio()` + ligne `NOTE` dans `ChangeLog_loukta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)