### PR TITLE
fix(security): 403 sur les endpoints REST tâche — checkUserAccessToObject interroge la mauvaise table (projet_task)

### DIFF
--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -1137,6 +1137,10 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 				}
 			} else {
 				$sharedelement = 'project'; // for multicompany compatibility
+				// The 'task' feature is remapped to 'project_task', but the physical table is 'projet_task'.
+				// Without this override $dbtablename stays 'project_task' -> query targets a non-existent table
+				// llx_project_task -> the entity check always fails -> spurious 403 on task read/update/delete.
+				$dbtablename = 'projet_task';
 				$sql = "SELECT COUNT(dbt.".$dbt_select.") as nb";
 				$sql .= " FROM ".MAIN_DB_PREFIX.$dbtablename." as dbt";
 				$sql .= " WHERE dbt.".$dbt_select." IN (".$db->sanitize($objectid, 1).")";


### PR DESCRIPTION
## Problème

Les endpoints REST sur une **tâche** (`GET /tasks/{id}`, `PUT/DELETE .../timespent/{id}`) renvoient un **403 « Access not allowed for login X »** pour un utilisateur qui a le droit « voir tous les projets » (`projet->all->lire`), alors même qu'il a accès au projet.

## Cause

Dans `checkUserAccessToObject()` (`htdocs/core/lib/security.lib.php`), la feature `task`/`projet_task` est remappée en `project_task`, et `$dbtablename` prend par défaut ce nom de feature. Quand l'utilisateur a `projet->all->lire`, la branche `else` de contrôle par entité construit :

```sql
SELECT COUNT(dbt.rowid) FROM llx_project_task as dbt WHERE ...
```

La table `llx_project_task` **n'existe pas** (la vraie table est `llx_projet_task`). La requête échoue → le contrôle retourne toujours `false` → 403.

La branche `checkproject` fonctionne car elle utilise `llx_projet` (table existante). D'où l'asymétrie : `GET /projects/{id}` = 200 mais `GET /tasks/{id}` = 403 pour le même projet.

## Correctif

Forcer la bonne table physique dans cette branche, sur le même modèle que l'override `$sharedelement = 'project'` déjà présent juste au-dessus :

```php
$dbtablename = 'projet_task';
```

## Vérification

- Reproduit sur Dolibarr 21.0.4 : `checkUserAccessToObject($user, ['task'], $taskid)` retournait `false` (table `llx_project_task` absente, `llx_projet_task` présente, `getEntity('project',1)` incluant bien l'entité de la tâche).
- Après correctif : le contrôle retourne `true`, `GET /tasks/{id}` = 200, `php -l` sans erreur.
- Bug présent aussi sur `develop` (contrôlé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
