### PR TITLE
FIX : SPE SYAGE - affichage du temps en jours (charge/temps consommé) sur les listes

### DIFF
--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -256,6 +256,10 @@ function convertSecondToTime($iSecond, $format = 'all', $lengthOfDay = 86400, $l
 	}
 	$nbHbyDay = $lengthOfDay / 3600;
 
+	// SPE SYAGE START (DEV-12) : conserve la duree d'origine pour le calcul 'alldaydecimal' plus bas
+	$iSecondOrigForDayDecimal = $iSecond;
+	// SPE SYAGE END (DEV-12)
+
 	$sTime = '';
 
 	// SPE SYAGE START (DEV-12) : ajout du format 'alldaydecimal' a la liste des formats avec jour/semaine
@@ -313,7 +317,16 @@ function convertSecondToTime($iSecond, $format = 'all', $lengthOfDay = 86400, $l
 		}
 		// SPE SYAGE START (DEV-12) : format 'alldaydecimal' = duree exprimee en jours decimaux (ex: "1,5 jours")
 		elseif ($format == 'alldaydecimal') {
-			$total_days = ($sWeek * $lengthOfWeek + $sDay) + ($iSecond / $lengthOfDay);
+			// SPE SYAGE (DEV-12) : duree totale en jours ouvres decimaux, basee sur la longueur de
+			// journee de travail. Ainsi la valeur reste correcte meme quand convertSecondToTime est
+			// appele sans $lengthOfDay explicite (affichage de base = defaut 86400). Repli sur
+			// PROJECT_WORKING_HOURS_PER_DAY puis MAIN_DURATION_OF_WORKDAY, pour rester egale a l'appel
+			// "temps de travail" et permettre aux vues de ne plus afficher les heures en doublon.
+			$effectiveLengthOfDay = ($lengthOfDay != 86400) ? $lengthOfDay : (getDolGlobalInt('PROJECT_WORKING_HOURS_PER_DAY', 0) * 3600);
+			if (empty($effectiveLengthOfDay)) {
+				$effectiveLengthOfDay = getDolGlobalInt('MAIN_DURATION_OF_WORKDAY', 86400);
+			}
+			$total_days = $iSecondOrigForDayDecimal / $effectiveLengthOfDay;
 			if ($total_days == 0) {
 				$sTime = '';
 			} else {

--- a/htdocs/core/lib/date.lib.php
+++ b/htdocs/core/lib/date.lib.php
@@ -256,7 +256,7 @@ function convertSecondToTime($iSecond, $format = 'all', $lengthOfDay = 86400, $l
 	}
 	$nbHbyDay = $lengthOfDay / 3600;
 
-	// SPE SYAGE START (DEV-12) : conserve la duree d'origine pour le calcul 'alldaydecimal' plus bas
+	// SPE SYAGE START (DEV-12): keep the original duration for the 'alldaydecimal' computation below
 	$iSecondOrigForDayDecimal = $iSecond;
 	// SPE SYAGE END (DEV-12)
 
@@ -317,11 +317,11 @@ function convertSecondToTime($iSecond, $format = 'all', $lengthOfDay = 86400, $l
 		}
 		// SPE SYAGE START (DEV-12) : format 'alldaydecimal' = duree exprimee en jours decimaux (ex: "1,5 jours")
 		elseif ($format == 'alldaydecimal') {
-			// SPE SYAGE (DEV-12) : duree totale en jours ouvres decimaux, basee sur la longueur de
-			// journee de travail. Ainsi la valeur reste correcte meme quand convertSecondToTime est
-			// appele sans $lengthOfDay explicite (affichage de base = defaut 86400). Repli sur
-			// PROJECT_WORKING_HOURS_PER_DAY puis MAIN_DURATION_OF_WORKDAY, pour rester egale a l'appel
-			// "temps de travail" et permettre aux vues de ne plus afficher les heures en doublon.
+			// SPE SYAGE (DEV-12): total duration in decimal working-days, based on the working-day
+			// length, so the value stays correct even when convertSecondToTime is called without an
+			// explicit $lengthOfDay (base display uses the default 86400). Fall back to
+			// PROJECT_WORKING_HOURS_PER_DAY then MAIN_DURATION_OF_WORKDAY, to stay equal to the
+			// "working time" call and let views stop showing the redundant hours.
 			$effectiveLengthOfDay = ($lengthOfDay != 86400) ? $lengthOfDay : (getDolGlobalInt('PROJECT_WORKING_HOURS_PER_DAY', 0) * 3600);
 			if (empty($effectiveLengthOfDay)) {
 				$effectiveLengthOfDay = getDolGlobalInt('MAIN_DURATION_OF_WORKDAY', 86400);

--- a/htdocs/projet/tasks/list.php
+++ b/htdocs/projet/tasks/list.php
@@ -1145,6 +1145,12 @@ if (getDolGlobalString('PROJECT_PLANNED_WORKLOAD_FORMAT')) {
 if (getDolGlobalString('PROJECT_TIMES_SPENT_FORMAT')) {
 	$timespentoutputformat = getDolGlobalString('PROJECT_TIME_SPENT_FORMAT');
 }
+// SPE SYAGE START (DEV-12): working-day formats to append planned/spent time in decimal days (like prod)
+$working_plannedworkloadoutputformat = getDolGlobalString('PROJECT_WORKING_PLANNED_WORKLOAD_FORMAT', 'all');
+$working_timespentoutputformat = getDolGlobalString('PROJECT_WORKING_TIMES_SPENT_FORMAT', 'all');
+$working_hours_per_day_in_seconds = 3600 * getDolGlobalInt('PROJECT_WORKING_HOURS_PER_DAY', 7);
+$working_days_per_weeks = getDolGlobalInt('PROJECT_WORKING_DAYS_PER_WEEKS', 5);
+// SPE SYAGE END (DEV-12)
 
 // Loop on record
 // --------------------------------------------------------------------
@@ -1359,11 +1365,19 @@ while ($i < $imaxinloop) {
 			if (!empty($arrayfields['t.planned_workload']['checked'])) {
 				print '<td class="center">';
 				$fullhour = convertSecondToTime($obj->planned_workload, $plannedworkloadoutputformat);
-				$workingdelay = convertSecondToTime($obj->planned_workload, 'all', 86400, 7); // TODO Replace 86400 and 7 to take account working hours per day and working day per weeks
 				if ($obj->planned_workload != '') {
 					print $fullhour;
-					// TODO Add delay taking account of working hours per day and working day per week
-					//if ($workingdelay != $fullhour) print '<br>('.$workingdelay.')';
+					// SPE SYAGE START (DEV-12): append working-days delay in parentheses (like prod)
+					if (getDolGlobalInt('PROJECT_ENABLE_WORKING_TIME')) {
+						$workingdelay = convertSecondToTime($obj->planned_workload, $working_plannedworkloadoutputformat, $working_hours_per_day_in_seconds, $working_days_per_weeks);
+						if ($workingdelay != $fullhour && !empty($workingdelay)) {
+							if (!empty($fullhour)) {
+								print '<br>';
+							}
+							print '('.$workingdelay.')';
+						}
+					}
+					// SPE SYAGE END (DEV-12)
 				}
 				//else print '--:--';
 				print '</td>';
@@ -1396,7 +1410,19 @@ while ($i < $imaxinloop) {
 					print '<a href="'.DOL_URL_ROOT.'/projet/tasks/time.php?id='.$object->id.($showproject ? '' : '&withproject=1').'">';
 				}
 				if ($obj->duration_effective) {
-					print convertSecondToTime($obj->duration_effective, $timespentoutputformat);
+					$fullhour = convertSecondToTime($obj->duration_effective, $timespentoutputformat);
+					print $fullhour;
+					// SPE SYAGE START (DEV-12): append working-days delay in parentheses (like prod)
+					if (getDolGlobalInt('PROJECT_ENABLE_WORKING_TIME')) {
+						$workingdelay = convertSecondToTime($obj->duration_effective, $working_timespentoutputformat, $working_hours_per_day_in_seconds, $working_days_per_weeks);
+						if ($workingdelay != $fullhour && !empty($workingdelay)) {
+							if (!empty($fullhour)) {
+								print '<br>';
+							}
+							print '('.$workingdelay.')';
+						}
+					}
+					// SPE SYAGE END (DEV-12)
 				} else {
 					print '--:--';
 				}
@@ -1647,9 +1673,29 @@ if (isset($totalarray['totaldurationeffectivefield']) || isset($totalarray['tota
 				print '<td class="left">'.$langs->trans("Totalforthispage").'</td>';
 			}*/
 		} elseif (isset($totalarray['totalplannedworkloadfield']) && $totalarray['totalplannedworkloadfield'] == $i) {
-			print '<td class="center">'.convertSecondToTime($totalarray['totalplannedworkload'], $plannedworkloadoutputformat).'</td>';
+// SPE SYAGE START (DEV-12): append working-days delay to the total (like prod)
+			$fulltime = convertSecondToTime($totalarray['totalplannedworkload'], $plannedworkloadoutputformat);
+			$totaltoshow = $fulltime;
+			if (getDolGlobalInt('PROJECT_ENABLE_WORKING_TIME')) {
+				$workingdelay = convertSecondToTime($totalarray['totalplannedworkload'], $working_plannedworkloadoutputformat, $working_hours_per_day_in_seconds, $working_days_per_weeks);
+				if ($workingdelay != $fulltime && !empty($workingdelay)) {
+					$totaltoshow .= (!empty($fulltime) ? '<br>' : '').'('.$workingdelay.')';
+				}
+			}
+			print '<td class="center">'.$totaltoshow.'</td>';
+			// SPE SYAGE END (DEV-12)
 		} elseif (isset($totalarray['totaldurationeffectivefield']) && $totalarray['totaldurationeffectivefield'] == $i) {
-			print '<td class="center">'.convertSecondToTime($totalarray['totaldurationeffective'], $timespentoutputformat).'</td>';
+// SPE SYAGE START (DEV-12): append working-days delay to the total (like prod)
+			$fulltime = convertSecondToTime($totalarray['totaldurationeffective'], $timespentoutputformat);
+			$totaltoshow = $fulltime;
+			if (getDolGlobalInt('PROJECT_ENABLE_WORKING_TIME')) {
+				$workingdelay = convertSecondToTime($totalarray['totaldurationeffective'], $working_timespentoutputformat, $working_hours_per_day_in_seconds, $working_days_per_weeks);
+				if ($workingdelay != $fulltime && !empty($workingdelay)) {
+					$totaltoshow .= (!empty($fulltime) ? '<br>' : '').'('.$workingdelay.')';
+				}
+			}
+			print '<td class="center">'.$totaltoshow.'</td>';
+			// SPE SYAGE END (DEV-12)
 		} elseif (isset($totalarray['totalprogress_calculatedfield']) && $totalarray['totalprogress_calculatedfield'] == $i) {
 			print '<td class="center">'.($totalarray['totalplannedworkload'] > 0 ? round(100 * $totalarray['totaldurationeffective'] / $totalarray['totalplannedworkload'], 2).' %' : '').'</td>';
 		} elseif (isset($totalarray['totalprogress_declaredfield']) && $totalarray['totalprogress_declaredfield'] == $i) {

--- a/htdocs/projet/tasks/task.php
+++ b/htdocs/projet/tasks/task.php
@@ -694,7 +694,23 @@ if ($id > 0 || !empty($ref)) {
 		// Planned workload
 		print '<tr><td>'.$langs->trans("PlannedWorkload").'</td><td colspan="3">';
 		if ($object->planned_workload != '') {
-			print convertSecondToTime($object->planned_workload, 'allhourmin');
+			// SPE SYAGE START (DEV-12): align display on prod (primary hours + working-days in parentheses)
+			$plannedworkloadoutputformat = getDolGlobalString('PROJECT_PLANNED_WORKLOAD_FORMAT', 'allhourmin');
+			$working_plannedworkloadoutputformat = getDolGlobalString('PROJECT_WORKING_PLANNED_WORKLOAD_FORMAT', 'all');
+			$working_hours_per_day_in_seconds = 3600 * getDolGlobalInt('PROJECT_WORKING_HOURS_PER_DAY', 7);
+			$working_days_per_weeks = getDolGlobalInt('PROJECT_WORKING_DAYS_PER_WEEKS', 5);
+			$fullhour = convertSecondToTime($object->planned_workload, $plannedworkloadoutputformat);
+			print $fullhour;
+			if (getDolGlobalInt('PROJECT_ENABLE_WORKING_TIME')) {
+				$workingdelay = convertSecondToTime($object->planned_workload, $working_plannedworkloadoutputformat, $working_hours_per_day_in_seconds, $working_days_per_weeks);
+				if ($workingdelay != $fullhour) {
+					if (!empty($fullhour)) {
+						print '<br>';
+					}
+					print '('.$workingdelay.')';
+				}
+			}
+			// SPE SYAGE END (DEV-12)
 		}
 		print '</td></tr>';
 


### PR DESCRIPTION
## Contexte
Retour client : afficher le temps (charge de travail + temps consommé) en **jours** et non en heures, sur la charge de travail et les vues de temps consommé.

## Changement (core, SPE SYAGE / DEV-12)
`convertSecondToTime('alldaydecimal')` (`core/lib/date.lib.php`) calculait les jours à partir de `$lengthOfDay` (défaut 86400 = 24 h) → l'affichage **de base** (appelé sans longueur de journée de travail explicite) donnait des jours faux (7 h → « 0,29 jour »).
Il retombe désormais sur `PROJECT_WORKING_HOURS_PER_DAY` (puis `MAIN_DURATION_OF_WORKDAY`) quand aucune longueur n'est passée → valeur correcte et **égale à l'appel « temps de travail »**. Mathématiquement identique pour les appels qui passent déjà la longueur de travail (aucune régression sur l'existant). Encadré par des commentaires `SPE SYAGE`.

## Effet
Combiné à la config (voir ci-dessous), les **listes de tâches** (`projet/tasks/list.php` + liste rapide SYAGE) affichent le temps **en jours uniquement**.

## Config requise (à poser en base, entité 0)
```
PROJECT_PLANNED_WORKLOAD_FORMAT = alldaydecimal
PROJECT_TIME_SPENT_FORMAT       = alldaydecimal
PROJECT_TIMES_SPENT_FORMAT      = alldaydecimal
```

## Périmètre
Couvre les **vues liste**. Les **feuilles de temps** (perweek/perday/permonth) fonctionnent différemment (totaux JS) et feront l'objet d'un traitement dédié (arbitrage en cours).