### PR TITLE
NEW : Backport ticket API contact linking on create (PR #39062)

### DIFF
--- a/ChangeLog_Koesio.md
+++ b/ChangeLog_Koesio.md
@@ -1,3 +1,4 @@
+- BACKPORT 24 - Adding contact on ticket creation from API + SPE noTrigger ticket creation from API - **2026-07-09**
 - BACKPORT 24 - T2605-4267 - (PR #38656) Backport Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail - **2026-06-09**
 - Backport 24 : https://github.com/Dolibarr/dolibarr/pull/37870 - **2026-04-15**
 - Backport 24 : https://github.com/Dolibarr/dolibarr/pull/37887 - **2026-04-15**

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -340,7 +340,14 @@ class Tickets extends DolibarrApi
 	/**
 	 * Create ticket object
 	 *
+	 * Optional key "contacts": an array of objects to link on creation, each:
+	 *   { "id": int (or "contactid"), "type": string (contact type code), "source": "external"|"internal" (default external) }
+	 * The whole creation is atomic: if any contact is invalid, the ticket is not created (rollback + error).
+	 * (Backport PR #39062 - https://github.com/Dolibarr/dolibarr/pull/39062)
+	 *
 	 * @param array $request_data   Request datas
+	 * @phan-param ?array<string,mixed> $request_data
+	 * @phpstan-param ?array<string,mixed> $request_data
 	 * @return int  ID of ticket
 	 */
 	public function post($request_data = null)
@@ -352,6 +359,19 @@ class Tickets extends DolibarrApi
 		// Check mandatory fields
 		$result = $this->_validate($request_data);
 
+		/*
+		* START BACKPORT Develop v24 -> PR #39062 - https://github.com/Dolibarr/dolibarr/pull/39062
+		*/
+		// Extract contacts to link after ticket creation (not a Ticket property to assign in the loop below)
+		$contacts = array();
+		if (isset($request_data['contacts']) && is_array($request_data['contacts'])) {
+			$contacts = $request_data['contacts'];
+		}
+		unset($request_data['contacts']);
+		/*
+		* END BACKPORT Develop v24 -> PR #39062 - https://github.com/Dolibarr/dolibarr/pull/39062
+		*/
+
 		foreach ($request_data as $field => $value) {
 			$this->ticket->$field = $value;
 		}
@@ -362,9 +382,37 @@ class Tickets extends DolibarrApi
 			$this->ticket->track_id = generate_random_id(16);
 		}
 
+		/*
+		* START BACKPORT Develop v24 -> PR #39062 - https://github.com/Dolibarr/dolibarr/pull/39062
+		*/
+		// Pre-validate contacts (format + type) BEFORE creating the ticket, so a malformed payload
+		// does not create a ticket (and fire its creation triggers) only to roll it back afterwards.
+		$contactsToLink = array();
+		if (is_array($contacts) && !empty($contacts)) {
+			foreach ($contacts as $contact) {
+				$contactsToLink[] = $this->_normalizeAndValidateContact($contact);
+			}
+		}
+
+		$this->db->begin();
+
 		if ($this->ticket->create(DolibarrApiAccess::$user) < 0) {
+			$this->db->rollback();
 			throw new RestException(500, "Error creating ticket", array_merge(array($this->ticket->error), $this->ticket->errors));
 		}
+
+		if (!empty($contactsToLink)) {
+			foreach ($contactsToLink as $contact) {
+				$result = $this->ticket->add_contact($contact['id'], $contact['type'], $contact['source']);
+				// Rolls back the transaction and throws a RestException on any failure
+				$this->_addContactResultOrThrow($result, $contact['id'], $contact['type'], $contact['source']);
+			}
+		}
+
+		$this->db->commit();
+		/*
+		* END BACKPORT Develop v24 -> PR #39062 - https://github.com/Dolibarr/dolibarr/pull/39062
+		*/
 
 		return $this->ticket->id;
 	}
@@ -515,6 +563,115 @@ class Tickets extends DolibarrApi
 		}
 		return $ticket;
 	}
+
+	/*
+	* START BACKPORT Develop v24 -> PR #39062 - https://github.com/Dolibarr/dolibarr/pull/39062
+	*/
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
+	/**
+	 * Check that an active contact type (code + source) exists for the ticket element.
+	 *
+	 * @param	string	$type	Contact type code (c_type_contact.code)
+	 * @param	string	$source	'internal' or 'external'
+	 * @return	bool			True if the active type exists for element 'ticket'
+	 */
+	private function _ticketContactTypeExists(string $type, string $source): bool
+	{
+		// phpcs:enable
+		$sql = "SELECT tc.rowid";
+		$sql .= " FROM ".$this->db->prefix()."c_type_contact as tc";
+		$sql .= " WHERE tc.element = 'ticket'";
+		$sql .= " AND tc.source = '".$this->db->escape($source)."'";
+		$sql .= " AND tc.code = '".$this->db->escape($type)."'";
+		$sql .= " AND tc.active = 1";
+
+		$resql = $this->db->query($sql);
+		if (!$resql) {
+			return false;
+		}
+		$exists = ($this->db->num_rows($resql) > 0);
+		$this->db->free($resql);
+
+		return $exists;
+	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
+	/**
+	 * Validate and normalize one contact entry from the API payload.
+	 * Called before any DB write, so it throws without rolling back.
+	 *
+	 * @param	mixed	$contact	Associative array {id|contactid:int, type:string, source?:string}
+	 * @phan-param	array{id?:int,contactid?:int,type?:string,source?:string}|mixed	$contact
+	 * @return	array				Normalized contact array{id:int,type:string,source:string}
+	 * @phan-return	array{id:int,type:string,source:string}
+	 * @throws	RestException
+	 */
+	private function _normalizeAndValidateContact($contact): array
+	{
+		// phpcs:enable
+		if (!is_array($contact)) {
+			throw new RestException(400, 'Each element of "contacts" must be an object with id, type and optional source');
+		}
+
+		$contactid = 0;
+		if (isset($contact['id'])) {
+			$contactid = (int) $contact['id'];
+		} elseif (isset($contact['contactid'])) {
+			$contactid = (int) $contact['contactid'];
+		}
+		$type = isset($contact['type']) ? trim((string) $contact['type']) : '';
+		$source = isset($contact['source']) ? (string) $contact['source'] : 'external';
+
+		if ($contactid <= 0) {
+			throw new RestException(400, 'Contact "id" is required and must be a positive integer');
+		}
+		if ($type === '') {
+			throw new RestException(400, 'Contact "type" (contact type code) is required');
+		}
+		if ($source !== 'internal' && $source !== 'external') {
+			throw new RestException(400, 'Contact "source" must be "internal" or "external"');
+		}
+		// Validate the type upfront so add_contact()'s ambiguous "0" return can only mean "already linked"
+		if (!$this->_ticketContactTypeExists($type, $source)) {
+			throw new RestException(400, 'Contact type "'.$type.'" not found or inactive for source "'.$source.'"');
+		}
+
+		return array('id' => $contactid, 'type' => $type, 'source' => $source);
+	}
+
+	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
+	/**
+	 * Map the return code of Ticket::add_contact() to an API response.
+	 * Assumes a DB transaction is open: rolls it back and throws on any failure.
+	 *
+	 * @param	int		$result		Return code of add_contact()
+	 * @param	int		$contactid	Contact id that was linked
+	 * @param	string	$type		Contact type code
+	 * @param	string	$source		'internal' or 'external'
+	 * @return	void
+	 * @throws	RestException
+	 */
+	private function _addContactResultOrThrow(int $result, int $contactid, string $type, string $source): void
+	{
+		// phpcs:enable
+		if ($result > 0) {
+			return;
+		}
+
+		$this->db->rollback();
+		if ($result == 0) {
+			// Type was validated upfront, so the only remaining 0 case is "already linked"
+			throw new RestException(409, 'Contact id='.$contactid.' is already linked to the ticket as source='.$source.' type='.$type);
+		} elseif ($result == -1) {
+			throw new RestException(404, 'Contact id='.$contactid.' not found');
+		} elseif ($result == -3 || $result == -4) {
+			throw new RestException(403, 'Not allowed to link contact id='.$contactid);
+		}
+		throw new RestException(500, 'Error linking contact id='.$contactid, array_merge(array($this->ticket->error), $this->ticket->errors));
+	}
+	/*
+	* END BACKPORT Develop v24 -> PR #39062 - https://github.com/Dolibarr/dolibarr/pull/39062
+	*/
 
 	// phpcs:disable PEAR.NamingConventions.ValidFunctionName.PublicUnderscore
 	/**

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -388,7 +388,7 @@ class Tickets extends DolibarrApi
 		// Pre-validate contacts (format + type) BEFORE creating the ticket, so a malformed payload
 		// does not create a ticket (and fire its creation triggers) only to roll it back afterwards.
 		$contactsToLink = array();
-		if (is_array($contacts) && !empty($contacts)) {
+		if (!empty($contacts)) {
 			foreach ($contacts as $contact) {
 				$contactsToLink[] = $this->_normalizeAndValidateContact($contact);
 			}

--- a/htdocs/ticket/class/api_tickets.class.php
+++ b/htdocs/ticket/class/api_tickets.class.php
@@ -396,10 +396,12 @@ class Tickets extends DolibarrApi
 
 		$this->db->begin();
 
-		if ($this->ticket->create(DolibarrApiAccess::$user) < 0) {
+		/* SPÉ KALI - create the ticket without firing TICKET_CREATE (notrigger=1) so the payload contacts are linked before the creation notification is sent */
+		if ($this->ticket->create(DolibarrApiAccess::$user, 1) < 0) {
 			$this->db->rollback();
 			throw new RestException(500, "Error creating ticket", array_merge(array($this->ticket->error), $this->ticket->errors));
 		}
+		/* SPÉ KALI - end */
 
 		if (!empty($contactsToLink)) {
 			foreach ($contactsToLink as $contact) {
@@ -408,6 +410,13 @@ class Tickets extends DolibarrApi
 				$this->_addContactResultOrThrow($result, $contact['id'], $contact['type'], $contact['source']);
 			}
 		}
+
+		/* SPÉ KALI - contacts are now linked: fire TICKET_CREATE so the creation notification reaches the ticket contacts */
+		if ($this->ticket->call_trigger('TICKET_CREATE', DolibarrApiAccess::$user) < 0) {
+			$this->db->rollback();
+			throw new RestException(500, "Error creating ticket", array_merge(array($this->ticket->error), $this->ticket->errors));
+		}
+		/* SPÉ KALI - end */
 
 		$this->db->commit();
 		/*

--- a/test/phpunit/TicketTest.php
+++ b/test/phpunit/TicketTest.php
@@ -158,6 +158,40 @@ class TicketTest extends PHPUnit\Framework\TestCase
 		return $result;
 	}
 
+	/*
+	* START BACKPORT Develop v24 -> PR #39062 - https://github.com/Dolibarr/dolibarr/pull/39062
+	*/
+	/**
+	 * Test Tickets::_ticketContactTypeExists via reflection.
+	 *
+	 * @return	void
+	 */
+	public function testTicketContactTypeExists()
+	{
+		global $conf,$user,$langs,$db;
+		$conf = $this->savconf;
+		$user = $this->savuser;
+		$langs = $this->savlangs;
+		$db = $this->savdb;
+
+		require_once dirname(__FILE__).'/../../htdocs/ticket/class/api_tickets.class.php';
+
+		$api = new Tickets();
+		$method = new ReflectionMethod('Tickets', '_ticketContactTypeExists');
+		$method->setAccessible(true);
+
+		// Known active seed types for element 'ticket'
+		$this->assertTrue($method->invoke($api, 'SUPPORTTEC', 'internal'), 'SUPPORTTEC/internal should exist');
+		$this->assertTrue($method->invoke($api, 'SUPPORTCLI', 'external'), 'SUPPORTCLI/external should exist');
+		// Wrong source for the code (SUPPORTTEC is internal only)
+		$this->assertFalse($method->invoke($api, 'SUPPORTTEC', 'external'), 'SUPPORTTEC is internal only');
+		// Unknown code
+		$this->assertFalse($method->invoke($api, 'NOT_A_REAL_CODE', 'external'), 'Unknown code must be false');
+	}
+	/*
+	* END BACKPORT Develop v24 -> PR #39062 - https://github.com/Dolibarr/dolibarr/pull/39062
+	*/
+
 	/**
 	 * testTicketFetch
 	 *


### PR DESCRIPTION
## Contexte

Backport de la PR Dolibarr [#39062](https://github.com/Dolibarr/dolibarr/pull/39062) (develop v24) dans `17.0_koesio_kali`.

Permet d'associer des contacts lors de la création d'un ticket via `POST /tickets`, grâce à une clé optionnelle `contacts` dans le payload.

## Modifications

**`htdocs/ticket/class/api_tickets.class.php`**
- `post()` : extraction + pré-validation des contacts *avant* création, création rendue atomique (`begin/commit/rollback`), liaison des contacts après création.
- Nouvelles méthodes privées : `_ticketContactTypeExists()`, `_normalizeAndValidateContact()`, `_addContactResultOrThrow()`.

**`test/phpunit/TicketTest.php`**
- Ajout de `testTicketContactTypeExists()`.

## Atomicité

Un contact invalide ⇒ aucun ticket créé (rollback), avec code HTTP explicite (400/403/404/409/500).

## Payload API attendu

```json
{ "subject": "...", "message": "...", "contacts": [ { "id": 42, "type": "SUPPORTCLI", "source": "external" } ] }
```

## Traçabilité

Chaque bloc backporté est encadré par des marqueurs `START/END BACKPORT Develop v24 -> PR #39062`, cohérents avec la convention déjà en place (cf. backport #37277 dans ce fichier).
