### PR TITLE
FIX: doc preview loupe on shipments (BL) in comm card

### DIFF
--- a/ChangeLogAtm.md
+++ b/ChangeLogAtm.md
@@ -1,3 +1,4 @@
+- FIX : Doc preview (magnifier/loupe) on shipments (BL) in thirdparty card (client/prospect tab) - use 'expedition' modulepart instead of $sendingstatic->element ('shipping') in comm/card.php - PR #755 - *2026-07-09*
 - FIX : BACKPORT pour SENTRY : add null check before setting _renderItem on jQuery UI autocomplete widget #37597
 - NEW : Add complete_substitutions_array in ticket.class.php - *2026-02-20*
 - FIX : DA027856 - Edition des extrafields "always editable" sur les projets avec une tache ouverte en bas de page.

--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -1099,8 +1099,6 @@ if ($object->id > 0) {
 	 *   Latest shipments
 	 */
 	if (isModEnabled("shipping") && $user->hasRight('expedition', 'lire')) {
-		$param = '';
-
 		$sql = 'SELECT e.rowid as id';
 		$sql .= ', e.ref, e.entity, e.fk_projet';
 		$sql .= ', e.date_creation';
@@ -1170,7 +1168,8 @@ if ($object->id > 0) {
 					}
 					$relativepath = dol_sanitizeFileName($objp->ref).'/'.dol_sanitizeFileName($objp->ref).'.pdf';
 
-					print $formfile->showPreview($file_list, $sendingstatic->element, $relativepath, 0, $param);
+					// Use the 'expedition' modulepart (not $sendingstatic->element which is 'shipping', an alias not handled by dol_check_secure_access_document())
+					print $formfile->showPreview($file_list, 'expedition', $relativepath, 0, 'entity=' . $objp->entity);
 				}
 				print '</td><td class="tdoverflowmax125">';
 				if ($sendingstatic->fk_project > 0) {

--- a/htdocs/comm/card.php
+++ b/htdocs/comm/card.php
@@ -1099,6 +1099,8 @@ if ($object->id > 0) {
 	 *   Latest shipments
 	 */
 	if (isModEnabled("shipping") && $user->hasRight('expedition', 'lire')) {
+		$param = '';
+
 		$sql = 'SELECT e.rowid as id';
 		$sql .= ', e.ref, e.entity, e.fk_projet';
 		$sql .= ', e.date_creation';
@@ -1168,8 +1170,11 @@ if ($object->id > 0) {
 					}
 					$relativepath = dol_sanitizeFileName($objp->ref).'/'.dol_sanitizeFileName($objp->ref).'.pdf';
 
-					// Use the 'expedition' modulepart (not $sendingstatic->element which is 'shipping', an alias not handled by dol_check_secure_access_document())
+					/**DEBUT SPECIFIQUE ATM **/
+					// Fix doc preview: use the 'expedition' modulepart instead of $sendingstatic->element ('shipping', a module-name alias not handled by dol_check_secure_access_document()), and pass the entity param like the other lists.
+					// Original core: print $formfile->showPreview($file_list, $sendingstatic->element, $relativepath, 0, $param);
 					print $formfile->showPreview($file_list, 'expedition', $relativepath, 0, 'entity=' . $objp->entity);
+					/**FIN SPECIFIQUE ATM **/
 				}
 				print '</td><td class="tdoverflowmax125">';
 				if ($sendingstatic->fk_project > 0) {


### PR DESCRIPTION
## Symptôme
Sur la fiche tiers (onglet Client/Prospect), cliquer sur la loupe d'aperçu PDF d'un BL renvoie la page générique de prod « This website or feature is currently temporarily not available… ». L'aperçu du même BL reste accessible depuis sa page dédiée.

## Cause racine
`comm/card.php` passait `$sendingstatic->element` (= `"shipping"`) comme `modulepart` à `showPreview()` → `document.php?modulepart=shipping`. Or `dol_check_secure_access_document()` (`core/lib/files.lib.php` ~3401) ne gère que `expedition`/`shipment` ; `shipping` n'est qu'un alias de nom de module (`MODULE_MAPPING`: `'expedition' => 'shipping'`, les fichiers sont stockés sous `expedition/sending/`). Le `modulepart=shipping` tombe dans la branche générique, teste `$conf->shipping->dir_output` (vide) → `dol_print_error("not supported value for modulepart parameter (shipping)")` + exit → masqué en prod.

Les 5 autres listes (devis, commandes, factures, contrats, interventions) fonctionnent car leur `->element` correspond déjà à un `modulepart` valide. Seule l'Expédition a `element` (`shipping`) ≠ `modulepart` (`expedition`). Les pages dédiées marchent car elles utilisent en dur `modulepart='expedition'` (`expedition/document.php:196`).

## Correctif
- Passer le `modulepart` `'expedition'` (comme la page dédiée) au lieu de `$sendingstatic->element`.
- Ajouter le paramètre `entity` qui manquait sur cette liste (multi-société), comme les autres listes.
- Suppression du `$param = ''` devenu inutile.

Même famille que la PR #37057 (`FIX/docPreviewInCommCard`), qui avait ajouté `entity=` aux listes sœurs mais laissé le bug de `modulepart` du BL.

## Portée
1 fichier, 2 lignes (`htdocs/comm/card.php`, bloc « Latest shipments »). Aucune migration, aucun effet de bord sur les autres listes. `php -l` OK.