### PR TITLE
FIX : define $arrayofselected in supplier payment list to fix blank page

### DIFF
--- a/htdocs/fourn/paiement/list.php
+++ b/htdocs/fourn/paiement/list.php
@@ -55,6 +55,9 @@ $langs->loadLangs(array('companies', 'bills', 'banks', 'compta'));
 
 $action = GETPOST('action', 'alpha');
 $massaction = GETPOST('massaction', 'alpha');
+// backport de V24
+$toselect = GETPOST('toselect', 'array:int'); // Array of ids of elements selected into a list
+// fin du backport
 $optioncss = GETPOST('optioncss', 'alpha');
 $contextpage = GETPOST('contextpage', 'aZ') ? GETPOST('contextpage', 'aZ') : 'vendorpaymentlist';
 $mode = GETPOST('mode', 'aZ');
@@ -303,6 +306,10 @@ if (!$resql) {
 
 $num = $db->num_rows($resql);
 $i = 0;
+
+// backport de V24
+$arrayofselected = is_array($toselect) ? $toselect : array();
+// fin du backport
 
 $param = '';
 if (!empty($contextpage) && $contextpage != $_SERVER["PHP_SELF"]) {


### PR DESCRIPTION
## Problème

La liste des règlements fournisseurs (**Fournisseurs → Règlements**, `fourn/paiement/list.php`) s'affiche vide : l'en-tête, les filtres et les titres de colonnes apparaissent, puis la page meurt à la première ligne de résultat.

```
Fatal error: Uncaught TypeError: in_array(): Argument #2 ($haystack) must be
of type array, null given in .../fourn/paiement/list.php on line 624
```

## Cause racine

`fourn/paiement/list.php` utilise `$arrayofselected` dans `in_array()` (l. 604/624/742) pour marquer les lignes sélectionnées, **mais ne le définit jamais**. Bug latent upstream : la page jumelle `compta/paiement/list.php` définit bien cette variable, pas celle-ci.

Il reste dormant car `Form::selectMassAction()` retourne `null` quand la page ne déclare aucune action de masse → `$massactionbutton` vide → le bloc gardé est ignoré. Dès qu'un module implémente le hook `addMoreMassActions` (ici le module `massaction`), `selectMassAction()` retourne un bouton non-vide → `$massactionbutton` devient vrai → `in_array($object->id, null)` → **TypeError fatal**.

## Correctif

Aligné sur `compta/paiement/list.php` (pattern Dolibarr standard) :
- lecture de `$toselect` via `GETPOST('toselect', 'array:int')` ;
- `$arrayofselected = is_array($toselect) ? $toselect : array();` avant la boucle d'affichage.

## Tests

- [x] `php -l` OK
- [x] `$arrayofselected` défini (l.308) avant ses 3 usages (607/627/745)
- [x] Rechargement de la page « Règlements fournisseurs » (à confirmer côté recette)

## Note

Même bug latent présent dans `htdocs/compta/localtax/list.php` (hors périmètre de cette PR) — à corriger si le bouton d'actions de masse peut y apparaître. Bug non spécifique au client : candidat à une remontée upstream Dolibarr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
