### PR TITLE
FIX : isole les pièces jointes d'une demande de congés dans un dossier partagé

### DIFF
--- a/ChangeLog-hobo.md
+++ b/ChangeLog-hobo.md
@@ -1,0 +1,15 @@
+# ChangeLog ATM — fork hobo (`atm/20.0_hobo`)
+
+Suivi des correctifs et évolutions **spécifiques ATM** appliqués au fork hobo, en
+complément du `ChangeLog` Dolibarr upstream (qui n'est pas modifié).
+
+## 20.0.4 — hobo
+
+### FIX
+- **Holiday** : les pièces jointes et le badge de comptage d'une demande de congés
+  affichaient aussi les fichiers d'autres demandes partageant le même dossier de
+  stockage (`get_exdir()` niveau 2 basé sur l'id). Ajout d'un filtrage par préfixe
+  de référence via la fonction utilitaire `holidayFilterOwnedFiles()`, utilisée dans
+  `holiday_prepare_head()` et `holiday/document.php`. Les portions spécifiques ATM
+  sont balisées `[ATM-MDV]` en vue de leur suppression en v23+ (le stockage y devient
+  propre par référence). _(branche `FIX/CONFLICT_DOCUMENTS_HOLIDAYS`)_

--- a/htdocs/core/lib/holiday.lib.php
+++ b/htdocs/core/lib/holiday.lib.php
@@ -46,7 +46,16 @@ function holiday_prepare_head($object)
 	// BACKPORT of https://github.com/Dolibarr/dolibarr/pull/38641 — remove when the upstream PR is merged and this file is updated
 	$upload_dir = $conf->holiday->multidir_output[$object->entity].'/'.get_exdir(0, 0, 0, 1, $object, 'holiday');
 	// END BACKPORT
-	$nbFiles = count(dol_dir_list($upload_dir, 'files', 0, '', '(\.meta|_preview.*\.png)$'));
+	/*
+	    [ATM-MDV] Début divergence ATM à retirer lors de la MDV v23+ :
+	    à partir de la v23 le stockage bascule sur un dossier propre par référence
+	    ('holiday' retiré de $arrayforoldpath dans get_exdir()), le filtrage par préfixe
+	    devient donc inutile. Remplacer les 2 lignes suivantes par la version upstream :
+	    $nbFiles = count(dol_dir_list($upload_dir, 'files', 0, '', '(\.meta|_preview.*\.png)$'));
+	*/
+	$allfilesbadge = dol_dir_list($upload_dir, 'files', 0, '', '(\.meta|_preview.*\.png)$');
+	$nbFiles = count(holidayFilterOwnedFiles($allfilesbadge, $object));
+	/* [ATM-MDV] Fin divergence ATM */
 	$nbLinks = Link::count($db, $object->element, $object->id);
 	$head[$h][0] = DOL_URL_ROOT.'/holiday/document.php?id='.$object->id;
 	$head[$h][1] = $langs->trans('Documents');
@@ -73,6 +82,43 @@ function holiday_prepare_head($object)
 
 	return $head;
 }
+
+
+/*
+    [ATM-MDV] Début divergence ATM à retirer lors de la MDV v23+ :
+    fonction spécifique ATM. En v23 le stockage bascule sur un dossier propre par
+    référence, le filtrage par préfixe n'a plus lieu d'être : supprimer toute cette
+    fonction ainsi que ses appels dans holiday_prepare_head() et holiday/document.php.
+*/
+/**
+ *  Filter a file list to keep only the attachments belonging to a given holiday.
+ *
+ *  Holiday attachments are stored using get_exdir() with a 2-level path forged from the
+ *  object id (see $arrayforoldpath in get_exdir()), so several holiday requests can share
+ *  the same physical directory. Each file is saved prefixed with the holiday reference
+ *  (e.g. "CP2401-0007-file.pdf"), or with the provisional reference "(PROVxx)" while the
+ *  request is still a draft. Filtering on that prefix isolates the files owned by $object
+ *  and avoids showing attachments from other requests sharing the same directory.
+ *
+ *  @param	array	$filearray	File list as returned by dol_dir_list() (each entry has a 'name' key)
+ *  @param	Holiday	$object		Holiday object owning the files
+ *  @return	array				Filtered and re-indexed file list (empty array if none match)
+ */
+function holidayFilterOwnedFiles($filearray, $object)
+{
+	if (!is_array($filearray) || empty($filearray)) {
+		return [];
+	}
+
+	$refprefix = dol_sanitizeFileName($object->ref);
+	$provprefix = dol_sanitizeFileName('(PROV'.$object->id.')');
+
+	return array_values(array_filter($filearray, function ($f) use ($refprefix, $provprefix) {
+		return strncmp($f['name'], $refprefix.'-', strlen($refprefix) + 1) === 0
+			|| strncmp($f['name'], $provprefix.'-', strlen($provprefix) + 1) === 0;
+	}));
+}
+/* [ATM-MDV] Fin divergence ATM */
 
 
 /**

--- a/htdocs/holiday/document.php
+++ b/htdocs/holiday/document.php
@@ -139,6 +139,13 @@ if ($object->id) {
 
 	// Build file list
 	$filearray = dol_dir_list($upload_dir, "files", 0, '', '(\.meta|_preview.*\.png)$', $sortfield, (strtolower($sortorder) == 'desc' ? SORT_DESC : SORT_ASC), 1);
+	/*
+	    [ATM-MDV] Début divergence ATM à retirer lors de la MDV v23+ :
+	    dossier de stockage partagé entre demandes (get_exdir niveau 2). En v23 le
+	    stockage devient propre par référence : supprimer la ligne de filtrage ci-dessous.
+	*/
+	$filearray = holidayFilterOwnedFiles($filearray, $object);
+	/* [ATM-MDV] Fin divergence ATM */
 	$totalsize = 0;
 	foreach ($filearray as $key => $file) {
 		$totalsize += $file['size'];


### PR DESCRIPTION

Le module Holiday stocke les fichiers via get_exdir() avec un chemin à 2 niveaux basé sur l'id, si bien que plusieurs demandes de congés partagent le même dossier physique. Le badge de comptage et la liste des pièces jointes affichaient donc aussi les fichiers d'autres demandes.

Ajout d'une fonction utilitaire holidayFilterOwnedFiles() qui ne conserve que les fichiers préfixés par la référence de la demande (ou la référence provisoire (PROVxx) pour un brouillon), utilisée dans holiday_prepare_head() et holiday/document.php.

Les portions spécifiques ATM sont balisées [ATM-MDV] en vue de leur suppression en v23+ (le stockage y devient propre par référence, filtrage inutile).

Ajout du test PHPUnit HolidayLibTest et du suivi ChangeLog-hobo.
