### PR TITLE
FIX : backport order stats "Created by" empty default (Dolibarr #39256)

### DIFF
--- a/htdocs/commande/stats/index.php
+++ b/htdocs/commande/stats/index.php
@@ -390,7 +390,13 @@ if (isModEnabled('category')) {
 // User
 print '<tr><td>'.$langs->trans("CreatedBy").'</td><td>';
 print img_picto('', 'user', 'class="pictofixedwidth"');
-print $form->select_dolusers($userid, 'userid', 1, null, 0, '', '', '0', 0, 0, '', 0, '', 'widthcentpercentminusx maxwidth300');
+// >>> BACKPORT Dolibarr #39256 - keep the "Created by" filter empty instead of defaulting to the current user.
+// The stats query is not filtered on the current user on first load, so preselecting them here wrongly suggests
+// the displayed figures are limited to that user while they are actually global. Pass -1 (not 0) so the combo
+// keeps its empty entry; -1 posts back and the query turns it into "no user filter", keeping the round-trip consistent.
+// Native once the upstream 23.0 fix (PR Dolibarr #39256) is merged back: remove this block at the next 23.0 merge.
+print $form->select_dolusers(($userid > 0 ? $userid : -1), 'userid', 1, null, 0, '', '', '0', 0, 0, '', 0, '', 'widthcentpercentminusx maxwidth300');
+// <<< BACKPORT Dolibarr #39256
 // Status
 print '<tr><td>'.$langs->trans("Status").'</td><td>';
 if ($mode == 'customer') {


### PR DESCRIPTION
## Contexte

Backport sur `23.0_syage` du fix standard upstream **Dolibarr PR #39256**
(https://github.com/Dolibarr/dolibarr/pull/39256).

## Problème

Sur la page de stats des commandes (`commande/stats/index.php`), à l'arrivée
la requête n'est **pas** filtrée sur l'utilisateur courant → les chiffres et
graphes affichés sont **globaux**. Mais le filtre **« Créé par »** se
pré-remplissait avec l'utilisateur courant (`select_dolusers` auto-sélectionne
`$user->id` quand la valeur passée est vide), laissant croire à tort que les
stats sont limitées à cet utilisateur.

## Correctif

On passe `-1` au lieu de `0` quand aucun utilisateur n'est sélectionné : la
combo garde son entrée vide et reflète la requête non filtrée. L'option vide
reposte `-1`, que la requête retraduit en « pas de filtre utilisateur » →
round-trip cohérent après rafraîchissement.

Le code est **entouré des marqueurs `>>> / <<< BACKPORT Dolibarr #39256`** :
à retirer au prochain merge de la branche 23.0 upstream (le fix y sera natif).

S'applique aux deux modes (`customer` et `supplier`, code partagé).
