### PR TITLE
FIX : display transferred entries in treasury journal (read on fk_doc)

### DIFF
--- a/htdocs/accountancy/journal/treasuryjournal.php
+++ b/htdocs/accountancy/journal/treasuryjournal.php
@@ -221,9 +221,9 @@ if ($resql) {
 				$sql .= " LEFT JOIN ".$db->prefix()."accounting_account as aa ON aa.rowid = fd.fk_code_ventilation";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=f.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=f.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE f.entity IN (".getEntity('facture', 0).')'; // We don't share object for accountancy, we use source object sharing
 				// Not already in bookkeeping
@@ -338,9 +338,9 @@ if ($resql) {
 				$sql .= " LEFT JOIN ".$db->prefix()."accounting_account as aa ON aa.rowid = ffd.fk_code_ventilation";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=ff.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=ff.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE ff.entity IN (".getEntity('facture_fourn', 0).')'; // We don't share object for accountancy, we use source object sharing
 				// Not already in bookkeeping
@@ -452,9 +452,9 @@ if ($resql) {
 				$sql .= " LEFT JOIN ".$db->prefix()."accounting_account as aa ON aa.account_number = ctf.accountancy_code";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=er.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=er.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE er.entity IN (".getEntity('expensereport', 0).')'; // We don't share object for accountancy, we use source object sharing
 				// Not already in bookkeeping
@@ -555,9 +555,9 @@ if ($resql) {
 				$sql .= " INNER JOIN ".$db->prefix()."bank_url as bu ON bu.url_id = ps.rowid AND bu.type = '".$db->escape($type)."'";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=ps.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=ps.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE ps.entity IN (".getEntity('user', 0).')'; // We don't share object for accountancy, we use source object sharing
 				// Not already in bookkeeping
@@ -623,9 +623,9 @@ if ($resql) {
 				$sql .= " LEFT JOIN ".$db->prefix()."c_chargesociales as ccs ON ccs.id = cs.fk_type";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=cs.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=cs.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE cs.entity = ".$conf->entity; // We don't share object for accountancy, we use source object sharing
 				// Not already in bookkeeping
@@ -690,9 +690,9 @@ if ($resql) {
 				$sql .= " INNER JOIN ".$db->prefix()."bank_url as bu ON bu.url_id = t.rowid AND bu.type = '".$db->escape($type)."'";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=t.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=t.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE bu.fk_bank IN (".$db->sanitize(implode(',', $ids)).")";
 				// $sql .= " AND t.entity = " . $conf->entity; // TODO when entity is managed in tva
@@ -757,9 +757,9 @@ if ($resql) {
 				$sql .= " INNER JOIN ".$db->prefix()."bank_url as bu ON bu.url_id = pd.rowid AND bu.type = '".$db->escape($type)."'";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=d.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=d.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE d.entity IN (".getEntity('donation', 0).')'; // We don't share object for accountancy, we use source object sharing
 				// Not already in bookkeeping
@@ -824,9 +824,9 @@ if ($resql) {
 				$sql .= " INNER JOIN ".$db->prefix()."bank_url as bu ON bu.url_id = pl.rowid AND bu.type = '".$db->escape($type)."'";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=l.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=l.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE l.entity = ".$conf->entity; // We don't share object for accountancy, we use source object sharing
 				// Not already in bookkeeping
@@ -913,9 +913,9 @@ if ($resql) {
 				$sql .= " INNER JOIN ".$db->prefix()."bank_url as bu ON bu.url_id = pv.rowid AND bu.type = '".$db->escape($type)."'";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=pv.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=pv.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE pv.entity IN (".getEntity('payment_various', 0).')';    // We don't share object for accountancy, we use source object sharing
 				$sql .= " AND bu.fk_bank IN (".$db->sanitize(implode(',', $ids)).")";
@@ -981,9 +981,9 @@ if ($resql) {
 				$sql .= " INNER JOIN ".$db->prefix()."bank_url as bu ON bu.fk_bank = su.fk_bank AND bu.type = '".$db->escape($type)."'";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=su.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=su.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE bu.fk_bank IN (".$db->sanitize(implode(',', $ids)).")";
 				// Not already in bookkeeping
@@ -1046,9 +1046,9 @@ if ($resql) {
 				$sql .= " LEFT JOIN ".$db->prefix()."bank_account as ba ON ba.rowid = b.fk_account";
 				// Already in bookkeeping or not
 				if ($in_bookkeeping == 'already') {
-					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=b.rowid";
+					$sql .= " INNER JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				} else {
-					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.fk_docdet=b.rowid";
+					$sql .= " LEFT JOIN ".$db->prefix()."accounting_bookkeeping as ab ON ab.fk_doc=bu.fk_bank AND ab.doc_type='bank'";
 				}
 				$sql .= " WHERE ba.entity IN (".getEntity('bank_account', 0).')'; // We don't share object for accountancy, we use source object sharing
 				$sql .= " AND bu.fk_bank IN (".$db->sanitize(implode(',', $ids)).")";

--- a/htdocs/core/menus/standard/eldy.lib.php
+++ b/htdocs/core/menus/standard/eldy.lib.php
@@ -1869,19 +1869,11 @@ function get_left_menu_accountancy($mainmenu, &$newmenu, $usemenuhider = 1, $lef
 								$key = $langs->trans("AccountingJournalType".$objp->nature);	// $objp->nature is 1, 2, 3 ...
 								$transferlabel = (($objp->nature && $key != "AccountingJournalType".$objp->nature) ? $key.($journallabelwithoutspan != $key ? ' '.$journallabel : '') : $journallabel);
 
-								// >>> PATCH HELLIOS - treasury-journal - DEBUT
-								// treasuryjournal.php possede un encodage fk_doc/fk_docdet incoherent (ecriture fk_docdet=0 vs lecture fk_docdet=id du document) :
-								// l'historique transfere n'est plus affiche et le re-transfert echoue ("deja enregistre") en mode RECETTES-DEPENSES.
-								// On force les journaux classiques par nature (bankjournal.php, etc.) comme avant la montee de version,
-								// coherents avec les ecritures deja presentes en base. A retirer une fois le correctif integre en amont (branche FIX/treasury-journal-fkdocdet).
-								$journalNaturePrefixUrl = $nature;
-								// Code d'origine neutralise :
-								// if (getDolGlobalString('ACCOUNTING_MODE') == 'RECETTES-DEPENSES') {
-								// 	$journalNaturePrefixUrl = 'treasury';
-								// } else {
-								// 	$journalNaturePrefixUrl = $nature;
-								// }
-								// >>> PATCH HELLIOS - treasury-journal - FIN
+								if (getDolGlobalString('ACCOUNTING_MODE') == 'RECETTES-DEPENSES') {
+									$journalNaturePrefixUrl = 'treasury';
+								} else {
+									$journalNaturePrefixUrl = $nature;
+								}
 								$newmenu->add('/accountancy/journal/'.$journalNaturePrefixUrl.'journal.php?mainmenu=accountancy&leftmenu=accountancy_journal&id_journal='.$objp->rowid, $transferlabel, 2, $user->hasRight('accounting', 'comptarapport', 'lire'));
 							}
 							$i++;


### PR DESCRIPTION
```
SELECT DISTINCT
    f.ref        AS facture,
    bu.fk_bank   AS ligne_bancaire,
    pf.amount
FROM llx_facturedet AS fd
    INNER JOIN llx_facture              AS f  ON f.rowid  = fd.fk_facture
    INNER JOIN llx_paiement_facture     AS pf ON pf.fk_facture = f.rowid
    INNER JOIN llx_bank_url             AS bu ON bu.url_id = pf.fk_paiement AND bu.type = 'payment'
    LEFT  JOIN llx_accounting_account   AS aa ON aa.rowid = fd.fk_code_ventilation
    -- Jointure corrigee : match sur la ligne bancaire (fk_doc) + doc_type, au lieu du champ deprecie fk_docdet
    -- Version buguee : INNER JOIN llx_accounting_bookkeeping AS ab ON ab.fk_doc = bu.fk_bank AND ab.fk_docdet = f.rowid
    INNER JOIN llx_accounting_bookkeeping AS ab ON ab.fk_doc = bu.fk_bank AND ab.doc_type = 'bank'
WHERE f.entity IN (1)
    AND fd.fk_code_ventilation > 0
    AND f.fk_statut            > 0
    AND fd.product_type        IN (0, 1)
    AND f.type                 IN (0, 1, 2, 3, 5)
    AND bu.fk_bank IN (
        -- lignes bancaires du journal 3 (BNPB) sur la periode
        SELECT b.rowid
        FROM llx_bank b
            JOIN llx_bank_account ba ON ba.rowid = b.fk_account
        WHERE ba.fk_accountancy_journal = 3
            AND ba.entity = 1
            AND b.dateo BETWEEN '2026-01-01' AND '2026-06-30'
    )
ORDER BY bu.fk_bank DESC;
```
