### PR TITLE
NEW (DEV-18) Add hooks to let modules add columns to the project overview lists

### DIFF
--- a/htdocs/projet/element.php
+++ b/htdocs/projet/element.php
@@ -1373,6 +1373,15 @@ foreach ($listofreferent as $key => $value) {
 			print '</td>';
 		}
 
+		// SPE SYAGE START (DEV-18) : hook d'ajout de colonnes, propose en upstream (PR Dolibarr #39459) - a retirer quand la PR est fusionnee
+		// Additional columns from hooks
+		$parameters = array('key' => $key, 'value' => $value, 'tablename' => $tablename);
+		$reshook = $hookmanager->executeHooks('printOverviewDetailTitle', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+		if ($reshook < 0) {
+			setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+		}
+		print $hookmanager->resPrint;
+		// SPE SYAGE END (DEV-18)
 
 		// Amount HT
 		//if (empty($value['disableamount']) && ! in_array($tablename, array('projet_task'))) print '<td class="right" width="120">'.$langs->trans("AmountHT").'</td>';
@@ -1673,6 +1682,15 @@ foreach ($listofreferent as $key => $value) {
 					print '</td>';
 				}
 
+				// SPE SYAGE START (DEV-18) : hook d'ajout de colonnes, propose en upstream (PR Dolibarr #39459) - a retirer quand la PR est fusionnee
+				// Additional columns from hooks
+				$parameters = array('key' => $key, 'value' => $value, 'tablename' => $tablename, 'element' => $element, 'i' => $i, 'qualifiedfortotal' => $qualifiedfortotal);
+				$reshook = $hookmanager->executeHooks('printOverviewDetailValue', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+				if ($reshook < 0) {
+					setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+				}
+				print $hookmanager->resPrint;
+				// SPE SYAGE END (DEV-18)
 
 				// Amount without tax
 				$warning = '';
@@ -1896,6 +1914,15 @@ foreach ($listofreferent as $key => $value) {
 				if ($tablename == 'fichinter') {
 					print '<td class="left">'.convertSecondToTime($total_duration, 'all', $conf->global->MAIN_DURATION_OF_WORKDAY).'</td>';
 				}
+				// SPE SYAGE START (DEV-18) : hook d'ajout de colonnes de totaux, propose en upstream (PR Dolibarr #39459) - a retirer quand la PR est fusionnee
+				// Additional total columns from hooks
+				$parameters = array('key' => $key, 'value' => $value, 'tablename' => $tablename, 'nbelement' => $i);
+				$reshook = $hookmanager->executeHooks('printOverviewDetailTotal', $parameters, $object, $action); // Note that $action and $object may have been modified by hook
+				if ($reshook < 0) {
+					setEventMessages($hookmanager->error, $hookmanager->errors, 'errors');
+				}
+				print $hookmanager->resPrint;
+				// SPE SYAGE END (DEV-18)
 				print '<td class="right">';
 				if (empty($value['disableamount'])) {
 					if ($key == 'loan') {


### PR DESCRIPTION
## Pourquoi

Les colonnes « Prix d'achat » et « Marge » des listes de la vue d'ensemble d'un projet existaient sur l'ancienne instance en Dolibarr 16, via un patch du cœur `16.0_syage`. Ce patch **n'a jamais été recensé** dans l'inventaire DEV-1 → DEV-21 : le lot DEV-18 couvrait quatre autres points, pas celui-là. Il n'a donc jamais été porté, et la fonction a disparu en v23.

## Ce que fait cette PR

Dolibarr 23 n'expose aucun point d'extension permettant d'insérer une colonne dans ces listes. Le seul hook existant, `printOverviewDetail`, remplace le bloc entier d'un type d'élément : environ 760 lignes de rendu du cœur, dont les actions lier/délier et leurs contrôles de droits.

Plutôt que dupliquer tout ça dans le module, trois hooks de sortie sont ajoutés, à la même position relative dans l'en-tête, dans chaque ligne et dans la ligne de totaux :

| Hook | Paramètres |
|---|---|
| `printOverviewDetailTitle` | `key`, `value`, `tablename` |
| `printOverviewDetailValue` | + `element`, `i`, `qualifiedfortotal` |
| `printOverviewDetailTotal` | + `nbelement` |

`qualifiedfortotal` est exposé parce que le cœur exclut déjà certains enregistrements de ses propres totaux (factures de remplacement, commandes annulées) : sans cette information, un module calculant son propre total afficherait une valeur incohérente avec le total HT juste à côté.

Aucun changement de comportement si aucun module n'implémente les hooks, et aucun nom de hook existant réutilisé, pour qu'une implémentation générique de `printFieldList*` qui ne teste pas son contexte ne puisse pas injecter de colonnes ici.

## Traçabilité

Le patch est encadré par des balises `SPE SYAGE (DEV-18)` renvoyant à la PR upstream, précisément pour qu'il ne se reperde pas à la prochaine montée de version majeure — ce qui est exactement la façon dont les colonnes d'origine ont disparu. À retirer, balises comprises, une fois la PR upstream fusionnée.

➡️ **PR upstream Dolibarr : https://github.com/Dolibarr/dolibarr/pull/39459** (ciblant `develop`, comme l'exige leur CONTRIBUTING pour une amélioration)

➡️ **MR module clisyage : http://gitlab.atm-consulting.fr/atm-consulting/clients/doli-cli-syage/-/merge_requests/57** — les colonnes ne s'affichent que si les deux sont en place. Sans ce patch, les hooks ne sont jamais appelés et **rien ne le signale**, aucune erreur.

## À noter, hors périmètre de cette PR

Cette branche est en retard d'un correctif upstream sur ce même fichier : `5acb9e3d771` (Fix #34684, double inversion de signe sur les commandes fournisseur pilotée par `PROJECT_ELEMENTS_FOR_MINUS_MARGIN`). Il touche le calcul du tableau « Bénéfice » de cette page. À resynchroniser séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)