### PR TITLE
NEW: API REST de réinitialisation de mot de passe (portails externes) + config admin

### DIFF
--- a/ChangeLogAtm.md
+++ b/ChangeLogAtm.md
@@ -1,4 +1,5 @@
 - FIX : Doc preview (magnifier/loupe) on shipments (BL) in thirdparty card (client/prospect tab) - use 'expedition' modulepart instead of $sendingstatic->element ('shipping') in comm/card.php - PR #755 - *2026-07-09*
+- NEW : Configuration UI (Accueil > Configuration > Sécurité, onglet Mots de passe) pour l'API de réinitialisation de mot de passe : activation de `USER_PASSWORD_RESET_PUBLIC_API` + champ `USER_PASSWORD_RESET_ALLOWED_RETURN_HOSTS` (plus besoin de passer par les constantes manuelles). - *2026-08-03*
 - NEW : API REST réinitialisation de mot de passe (`passwordpolicy` / `passwordresetrequest` / `passwordresetconfirm` dans api_users) pour un flux "mot de passe oublié" transparent côté portail ; opt-in `USER_PASSWORD_RESET_PUBLIC_API`, lien email vers `returnurl` whitelisté (`USER_PASSWORD_RESET_ALLOWED_RETURN_HOSTS`), anti-énumération, validation politique via setPassword. - *2026-06-24*
 - FIX : BACKPORT pour SENTRY : add null check before setting _renderItem on jQuery UI autocomplete widget #37597
 - NEW : Add complete_substitutions_array in ticket.class.php - *2026-02-20*

--- a/ChangeLogAtm.md
+++ b/ChangeLogAtm.md
@@ -1,4 +1,5 @@
 - FIX : Doc preview (magnifier/loupe) on shipments (BL) in thirdparty card (client/prospect tab) - use 'expedition' modulepart instead of $sendingstatic->element ('shipping') in comm/card.php - PR #755 - *2026-07-09*
+- NEW : API REST réinitialisation de mot de passe (`passwordpolicy` / `passwordresetrequest` / `passwordresetconfirm` dans api_users) pour un flux "mot de passe oublié" transparent côté portail ; opt-in `USER_PASSWORD_RESET_PUBLIC_API`, lien email vers `returnurl` whitelisté (`USER_PASSWORD_RESET_ALLOWED_RETURN_HOSTS`), anti-énumération, validation politique via setPassword. - *2026-06-24*
 - FIX : BACKPORT pour SENTRY : add null check before setting _renderItem on jQuery UI autocomplete widget #37597
 - NEW : Add complete_substitutions_array in ticket.class.php - *2026-02-20*
 - FIX : DA027856 - Edition des extrafields "always editable" sur les projets avec une tache ouverte en bas de page.

--- a/htdocs/admin/security.php
+++ b/htdocs/admin/security.php
@@ -154,6 +154,13 @@ if ($action == 'activate_MAIN_SECURITY_DISABLEFORGETPASSLINK') {
 	dolibarr_del_const($db, "MAIN_SECURITY_DISABLEFORGETPASSLINK", $conf->entity);
 }
 
+if ($action == 'update_reset_hosts') {
+	dolibarr_set_const($db, "USER_PASSWORD_RESET_ALLOWED_RETURN_HOSTS", GETPOST('reset_hosts', 'alphanohtml'), 'chaine', 0, '', $conf->entity);
+	setEventMessages($langs->trans("SetupSaved"), null, 'mesgs');
+	header("Location: security.php");
+	exit;
+}
+
 if ($action == 'updatepattern') {
 	$pattern = GETPOST("pattern", "alpha");
 	$explodePattern = explode(';', $pattern);  // List of ints separated with ';' containing counts
@@ -493,6 +500,26 @@ print '</tr>';
 
 print '</table>';
 
+print '</form>';
+
+print '<br>';
+
+// Public password reset REST API (consumed by external portals, e.g. AskDoli). Off by default.
+print load_fiche_titre($langs->trans("PasswordResetPublicAPI"), '', '');
+print '<form method="POST" action="'.$_SERVER["PHP_SELF"].'">';
+print '<input type="hidden" name="token" value="'.newToken().'">';
+print '<input type="hidden" name="action" value="update_reset_hosts">';
+print '<table class="noborder centpercent">';
+print '<tr class="liste_titre"><td>'.$langs->trans("Parameter").'</td><td>'.$langs->trans("Value").'</td></tr>';
+print '<tr class="oddeven"><td>'.$langs->trans("EnablePasswordResetPublicAPI").'</td><td>';
+print ajax_constantonoff('USER_PASSWORD_RESET_PUBLIC_API');
+print '</td></tr>';
+print '<tr class="oddeven"><td>'.$langs->trans("PasswordResetAllowedReturnHosts").'</td><td>';
+print '<input type="text" class="minwidth300" name="reset_hosts" value="'.dol_escape_htmltag(getDolGlobalString('USER_PASSWORD_RESET_ALLOWED_RETURN_HOSTS')).'">';
+print '<br><span class="opacitymedium small">'.$langs->trans("PasswordResetAllowedReturnHostsHelp").'</span>';
+print '</td></tr>';
+print '</table>';
+print '<div class="center paddingtop"><input type="submit" class="button" value="'.$langs->trans("Save").'"></div>';
 print '</form>';
 
 print '<br>';

--- a/htdocs/langs/en_US/admin.lang
+++ b/htdocs/langs/en_US/admin.lang
@@ -2604,3 +2604,7 @@ AttributeCodeHelp=A code of your choice (without special chars and spaces) to id
 ThereIsMoreThanXAnswers=There is more than %s answers with your filter. Please add more filters...
 PdfAddTermOfSaleHelp=You can upload the terms and conditions of sale file at the bottom of this setup page
 WarningOnlineSignature=Please note that this function allows a person (customer, supplier...) to insert, online, the image of his signature in the PDF document. As for a handwritten signature, such a signature can be made by anyone and might not have the same legal value as a legal electronic signature system going through an authorized trusted third party. If you need this level of security, you can contact an integrator for more information or check for addons on %s.
+PasswordResetPublicAPI=Public password reset API
+EnablePasswordResetPublicAPI=Enable the public password reset REST API (used by external portals)
+PasswordResetAllowedReturnHosts=Allowed return hosts for the reset link
+PasswordResetAllowedReturnHostsHelp=Comma-separated list of hostnames allowed as the reset link return URL (e.g. portal.example.com)

--- a/htdocs/langs/fr_FR/admin.lang
+++ b/htdocs/langs/fr_FR/admin.lang
@@ -2630,3 +2630,7 @@ AvailableWithSomePDFTemplatesOnly=Fonctionnalité non prise en charge sur les an
 SelectAService=Select the kind of service to use
 SelectFeatureToTest=Select the feature to test
 AIModelForFeature=AI model for features (AI service %s)
+PasswordResetPublicAPI=API publique de réinitialisation de mot de passe
+EnablePasswordResetPublicAPI=Activer l'API REST publique de réinitialisation de mot de passe (utilisée par des portails externes)
+PasswordResetAllowedReturnHosts=Hôtes autorisés pour le lien de retour de réinitialisation
+PasswordResetAllowedReturnHostsHelp=Liste d'hôtes séparés par des virgules, autorisés comme URL de retour du lien de réinitialisation (ex : portail.example.com)

--- a/htdocs/user/class/api_users.class.php
+++ b/htdocs/user/class/api_users.class.php
@@ -504,6 +504,238 @@ class Users extends DolibarrApi
 	}
 
 	/**
+	 * Get the password policy of this instance
+	 *
+	 * Returns the password constraints (minimum length and minimum count of
+	 * uppercase, digit and special characters) derived from the active password
+	 * generator (USER_PASSWORD_GENERATED / USER_PASSWORD_PATTERN), so a portal
+	 * front-end can display and pre-validate them before a reset. Read-only.
+	 *
+	 * Gated by the constant USER_PASSWORD_RESET_PUBLIC_API (off by default) and
+	 * meant to be called server-to-server with a system API key.
+	 *
+	 * @return  array   Password policy {minLength, minUpper, minDigits, minSpecial, generator}
+	 * @phan-return array<string,int|string>
+	 *
+	 * @throws RestException 403 Feature disabled or not allowed
+	 *
+	 * @url GET passwordpolicy
+	 */
+	public function passwordPolicy()
+	{
+		global $conf, $langs;
+
+		if (!getDolGlobalString('USER_PASSWORD_RESET_PUBLIC_API')) {
+			throw new RestException(403, 'Public password reset API is disabled (constant USER_PASSWORD_RESET_PUBLIC_API).');
+		}
+		if (!DolibarrApiAccess::$user->hasRight('user', 'user', 'password') && empty(DolibarrApiAccess::$user->admin)) {
+			throw new RestException(403, 'Not allowed');
+		}
+
+		$generator = getDolGlobalString('USER_PASSWORD_GENERATED');
+		$policy = array('minLength' => 0, 'minUpper' => 0, 'minDigits' => 0, 'minSpecial' => 0, 'generator' => $generator);
+
+		if (!empty($generator)) {
+			$classname = 'modGeneratePass'.ucfirst($generator);
+			$file = DOL_DOCUMENT_ROOT.'/core/modules/security/generate/'.$classname.'.class.php';
+			if (file_exists($file)) {
+				include_once $file;
+				if (class_exists($classname)) {
+					$modgen = new $classname($this->db, $conf, $langs, DolibarrApiAccess::$user);
+					$policy['minLength'] = (int) (isset($modgen->length2) ? $modgen->length2 : (isset($modgen->length) ? $modgen->length : 0));
+					$policy['minUpper'] = (int) (isset($modgen->NbMaj) ? $modgen->NbMaj : 0);
+					$policy['minDigits'] = (int) (isset($modgen->NbNum) ? $modgen->NbNum : 0);
+					$policy['minSpecial'] = (int) (isset($modgen->NbSpe) ? $modgen->NbSpe : 0);
+				}
+			}
+		}
+
+		return $policy;
+	}
+
+	/**
+	 * Request a password reset link
+	 *
+	 * Generates a temporary password for the matching user and emails a reset
+	 * LINK pointing to the provided portal returnurl (no password is included in
+	 * the email body). The response is identical whether or not an account
+	 * matches (anti-enumeration). Gated by USER_PASSWORD_RESET_PUBLIC_API and
+	 * meant to be called server-to-server with a system API key holding the
+	 * user/password right.
+	 *
+	 * @param   array   $request_data   Request data {login_or_email, returnurl}
+	 * @return  array   Neutral acknowledgement {success}
+	 * @phan-return array<string,bool>
+	 *
+	 * @throws RestException 400 Bad parameters or returnurl host not allowed
+	 * @throws RestException 403 Feature disabled or not allowed
+	 *
+	 * @url POST passwordresetrequest
+	 */
+	public function passwordResetRequest($request_data = null)
+	{
+		global $conf;
+
+		if (!getDolGlobalString('USER_PASSWORD_RESET_PUBLIC_API')) {
+			throw new RestException(403, 'Public password reset API is disabled (constant USER_PASSWORD_RESET_PUBLIC_API).');
+		}
+		if (!DolibarrApiAccess::$user->hasRight('user', 'user', 'password') && empty(DolibarrApiAccess::$user->admin)) {
+			throw new RestException(403, 'Not allowed');
+		}
+
+		$loginoremail = (is_array($request_data) && isset($request_data['login_or_email'])) ? trim((string) $request_data['login_or_email']) : '';
+		$returnurl = (is_array($request_data) && isset($request_data['returnurl'])) ? trim((string) $request_data['returnurl']) : '';
+		if ($loginoremail === '' || $returnurl === '') {
+			throw new RestException(400, 'Parameters login_or_email and returnurl are mandatory');
+		}
+
+		// Validate the returnurl host against the whitelist (anti open-redirect / phishing)
+		$allowedhosts = array_filter(array_map('trim', explode(',', getDolGlobalString('USER_PASSWORD_RESET_ALLOWED_RETURN_HOSTS'))));
+		$returnhost = parse_url($returnurl, PHP_URL_HOST);
+		if (empty($returnhost) || !in_array($returnhost, $allowedhosts, true)) {
+			throw new RestException(400, 'returnurl host is not in the allowed list (constant USER_PASSWORD_RESET_ALLOWED_RETURN_HOSTS)');
+		}
+
+		$edituser = new User($this->db);
+		if (strpos($loginoremail, '@') !== false) {
+			$resfetch = $edituser->fetch(0, '', '', 0, -1, $loginoremail);
+		} else {
+			$resfetch = $edituser->fetch(0, $loginoremail);
+		}
+
+		if ($resfetch > 0 && !empty($edituser->email)) {
+			$newpassword = $edituser->setPassword(DolibarrApiAccess::$user, '', 1);	// Generate + store a temporary password (clear) in pass_temp
+			if (is_int($newpassword) && $newpassword < 0) {
+				dol_syslog("Users::passwordResetRequest failed to set temporary password for user ".((int) $edituser->id)." : ".$edituser->error, LOG_ERR);
+			} else {
+				$hash = dol_hash($newpassword.'-'.$edituser->id.'-'.$conf->file->instance_unique_id);
+				$this->sendPasswordResetLinkEmail($edituser, $returnurl, $hash);
+			}
+		} else {
+			usleep(20000);	// Simulate processing delay so response time does not leak account existence
+		}
+
+		// Always neutral: never reveal whether the account exists
+		return array('success' => true);
+	}
+
+	/**
+	 * Confirm a password reset and set the user-chosen new password
+	 *
+	 * Verifies the possession hash received by email, then sets the new password.
+	 * The new password is validated against the instance password policy by
+	 * User::setPassword (returns < 0 with an error if it does not comply). Gated
+	 * by USER_PASSWORD_RESET_PUBLIC_API and meant to be called server-to-server
+	 * with a system API key holding the user/password right.
+	 *
+	 * @param   array   $request_data   Request data {username, passworduidhash, newpassword}
+	 * @return  array   {success}
+	 * @phan-return array<string,bool>
+	 *
+	 * @throws RestException 400 Bad parameters
+	 * @throws RestException 403 Feature disabled, not allowed, or invalid/expired link
+	 * @throws RestException 422 New password does not meet the password policy
+	 *
+	 * @url POST passwordresetconfirm
+	 */
+	public function passwordResetConfirm($request_data = null)
+	{
+		global $conf;
+
+		if (!getDolGlobalString('USER_PASSWORD_RESET_PUBLIC_API')) {
+			throw new RestException(403, 'Public password reset API is disabled (constant USER_PASSWORD_RESET_PUBLIC_API).');
+		}
+		if (!DolibarrApiAccess::$user->hasRight('user', 'user', 'password') && empty(DolibarrApiAccess::$user->admin)) {
+			throw new RestException(403, 'Not allowed');
+		}
+
+		$username = (is_array($request_data) && isset($request_data['username'])) ? trim((string) $request_data['username']) : '';
+		$hash = (is_array($request_data) && isset($request_data['passworduidhash'])) ? trim((string) $request_data['passworduidhash']) : '';
+		$newpassword = (is_array($request_data) && isset($request_data['newpassword'])) ? (string) $request_data['newpassword'] : '';
+		if ($username === '' || $hash === '' || $newpassword === '') {
+			throw new RestException(400, 'Parameters username, passworduidhash and newpassword are mandatory');
+		}
+
+		$edituser = new User($this->db);
+		$resfetch = $edituser->fetch(0, $username);
+		if ($resfetch <= 0 || empty($edituser->pass_temp)
+			|| !dol_verifyHash($edituser->pass_temp.'-'.$edituser->id.'-'.$conf->file->instance_unique_id, $hash)) {
+			// Generic message: never reveal which part failed (anti-enumeration)
+			throw new RestException(403, 'Invalid or expired password reset link');
+		}
+
+		$result = $edituser->setPassword(DolibarrApiAccess::$user, $newpassword, 0);
+		if (is_int($result) && $result < 0) {
+			throw new RestException(422, $edituser->error ? $edituser->error : 'New password does not meet the password policy');
+		}
+
+		return array('success' => true);
+	}
+
+	/**
+	 * Send a password-reset LINK email pointing to a portal returnurl (no password in body)
+	 *
+	 * @param   User    $edituser   User to email (must hold an email address)
+	 * @param   string  $returnurl  Portal base URL of the reset page (already whitelisted)
+	 * @param   string  $hash       Possession hash to append to the link
+	 * @return  int                 Return integer < 0 if KO, > 0 if OK
+	 */
+	private function sendPasswordResetLinkEmail($edituser, $returnurl, $hash)
+	{
+		global $conf, $langs;
+
+		require_once DOL_DOCUMENT_ROOT.'/core/class/CMailFile.class.php';
+
+		$outputlangs = $langs;
+		if (getDolGlobalString('MAIN_LANG_DEFAULT')) {
+			$outputlangs = new Translate('', $conf);
+			$outputlangs->setDefaultLang(getDolGlobalString('MAIN_LANG_DEFAULT'));
+		}
+		$outputlangs->loadLangs(array('main', 'errors', 'users', 'other'));
+
+		$appli = getDolGlobalString('MAIN_APPLICATION_TITLE', constant('DOL_APPLICATION_TITLE'));
+
+		$link = $returnurl.((strpos($returnurl, '?') === false) ? '?' : '&');
+		$link .= 'username='.urlencode($edituser->login).'&passworduidhash='.urlencode($hash);
+
+		$subject = '['.$appli.'] '.$outputlangs->transnoentitiesnoconv('SubjectNewPassword', $appli);
+
+		$mesg = $outputlangs->transnoentitiesnoconv('RequestToResetPasswordReceived')."<br>\n<br>\n";
+		$mesg .= $outputlangs->transnoentitiesnoconv('YouMustClickToChange')." :<br>\n";
+		$mesg .= '<a href="'.dol_escape_htmltag($link).'" rel="noopener">'.$outputlangs->transnoentitiesnoconv('ConfirmPasswordChange').'</a>'."<br>\n<br>\n";
+		$mesg .= $outputlangs->transnoentitiesnoconv('ForgetIfNothing')."<br>\n";
+
+		$trackid = 'use'.$edituser->id;
+		$sendcontext = 'passwordreset';
+
+		$mailfile = new CMailFile(
+			$subject,
+			$edituser->email,
+			getDolGlobalString('MAIN_MAIL_EMAIL_FROM'),
+			$mesg,
+			array(),
+			array(),
+			array(),
+			'',
+			'',
+			0,
+			1,
+			'',
+			'',
+			$trackid,
+			'',
+			$sendcontext
+		);
+
+		if (!$mailfile->sendfile()) {
+			dol_syslog("Users::sendPasswordResetLinkEmail failed to send to user ".((int) $edituser->id)." : ".$mailfile->error, LOG_ERR);
+			return -1;
+		}
+
+		return 1;
+	}
+
+	/**
 	 * List the groups of a user
 	 *
 	 * @param int $id     Id of user


### PR DESCRIPTION
## API REST de réinitialisation de mot de passe (pour portails externes, ex. AskDoli)

Flux « mot de passe oublié » transparent in-portal : un portail externe (AskDoli) relaie vers Dolibarr via la clé API système ; l'utilisateur final reste anonyme dans le navigateur.

### Endpoints (`htdocs/user/class/api_users.class.php`)
- `GET /users/passwordpolicy` — renvoie les contraintes du générateur actif (minLength/minUpper/minDigits/minSpecial) pour affichage + pré-validation côté portail.
- `POST /users/passwordresetrequest {login_or_email, returnurl}` — arme un mot de passe temporaire, envoie un email **lien-seul** (aucun mot de passe en clair) vers `returnurl?username=…&passworduidhash=…` ; l'host de `returnurl` est validé contre une whitelist ; réponse **toujours** `{success:true}` (anti-énumération).
- `POST /users/passwordresetconfirm {username, passworduidhash, newpassword}` — vérifie le hash de possession, puis pose le mot de passe **choisi par l'utilisateur** (validé contre la politique active → 422 si non conforme).
- Les 3 sont **opt-in** via `USER_PASSWORD_RESET_PUBLIC_API` (403 si off) + `hasRight('user','user','password')||admin`. Aucune migration DB (réutilise `pass_temp`).

### Config admin (`htdocs/admin/security.php`, onglet Mots de passe)
- Nouvelle section « API publique de réinitialisation de mot de passe » : un **switch** pour `USER_PASSWORD_RESET_PUBLIC_API` et un **champ** pour `USER_PASSWORD_RESET_ALLOWED_RETURN_HOSTS` (plus besoin de l'éditeur générique de constantes). Clés i18n FR + EN.

### Vérification
`php -l` clean ; audit GEM compact PASS ; test live 6/6 (constantes activées de façon réversible) : policy→200, request anti-énum→success, mauvais returnurl→400, confirm bad-hash→403, manquant→400. E2E validé de bout en bout via le portail AskDoli.

### Notes
- Le correctif indépendant « 403 parasite de l'API tâches » a été **sorti dans son propre PR** (#772).
- La refonte de la page « mot de passe oublié » **native** de Dolibarr est un **PR communautaire séparé** (email lien-seul + mot de passe choisi + TTL + helpers partagés). Quand elle atterrira sur develop, ces endpoints REST devront être rebasés sur ses helpers partagés (DRY) — hors périmètre de ce PR gamme ATM.
