### PR TITLE
FIX: 403 parasite sur l'API REST des tâches (checkUserAccessToObject, mauvaise table)

### DIFF
--- a/ChangeLogAtm.md
+++ b/ChangeLogAtm.md
@@ -1,3 +1,4 @@
+- FIX : API REST des tâches (GET/PUT/DELETE /tasks/{id}) renvoyait un 403 parasite — checkUserAccessToObject ciblait la table inexistante llx_project_task au lieu de llx_projet_task. - *2026-08-28*
 - FIX : Doc preview (magnifier/loupe) on shipments (BL) in thirdparty card (client/prospect tab) - use 'expedition' modulepart instead of $sendingstatic->element ('shipping') in comm/card.php - PR #755 - *2026-07-09*
 - FIX : BACKPORT pour SENTRY : add null check before setting _renderItem on jQuery UI autocomplete widget #37597
 - NEW : Add complete_substitutions_array in ticket.class.php - *2026-02-20*

--- a/htdocs/core/lib/security.lib.php
+++ b/htdocs/core/lib/security.lib.php
@@ -1137,6 +1137,10 @@ function checkUserAccessToObject($user, array $featuresarray, $object = 0, $tabl
 				}
 			} else {
 				$sharedelement = 'project'; // for multicompany compatibility
+				// FIX: the 'task' feature is remapped to 'project_task', but the physical table is 'projet_task'.
+				// Without this override $dbtablename stays 'project_task' -> query targets a non-existent table
+				// llx_project_task -> the entity check always fails -> spurious 403 on task read/update/delete.
+				$dbtablename = 'projet_task';
 				$sql = "SELECT COUNT(dbt.".$dbt_select.") as nb";
 				$sql .= " FROM ".MAIN_DB_PREFIX.$dbtablename." as dbt";
 				$sql .= " WHERE dbt.".$dbt_select." IN (".$db->sanitize($objectid, 1).")";


### PR DESCRIPTION
## FIX : 403 parasite sur l'API REST des tâches

`checkUserAccessToObject()` remappe la feature `task` → `project_task`, donc `$dbtablename` devient `project_task` et la requête de contrôle d'entité vise `llx_project_task` — une table qui **n'existe pas** (la vraie = `llx_projet_task`). Pour un utilisateur ayant `projet->all->lire=1`, le code passe dans cette branche SQL, la requête échoue, le contrôle renvoie `false`, et `GET/PUT/DELETE /tasks/{id}` répond **403** alors que le même projet est accessible. (La branche `project` fonctionne car elle utilise `projet` et `llx_projet` existe.)

### Correctif
Dans la branche `else` de `$checktask`, forcer le nom physique de table (`$dbtablename = 'projet_task'`) avant de construire le SQL, en miroir de l'override `$sharedelement` existant. Strictement limité à la feature `task` ; le filtre entité est **préservé** (aucun relâchement de sécurité, juste la bonne table). 4 lignes dans `htdocs/core/lib/security.lib.php`.

Correctif **indépendant**, extrait de la branche `forgot-password-rest-api` où il avait été committé par commodité.
