### PR TITLE
FIX : prorate situation invoice buy price in progress mode (INVOICE_USE_SITUATION = 2)

### DIFF
--- a/ChangeLog_calegari
+++ b/ChangeLog_calegari
@@ -1,0 +1,33 @@
+# ChangeLog Calegari
+
+Core patches applied on top of Dolibarr 23.0 for this instance.
+
+Every entry below lives in a core file, so it is overwritten by each core
+upgrade and MUST be re-applied until the matching upstream pull request lands.
+Check this file after every upgrade.
+
+## 23.0 - 31/08/2026
+
+- FIX : situation invoice margin — prorate the buy price by `situation_percent`
+  in progress mode (`INVOICE_USE_SITUATION = 2`), and stop the sign flip on
+  situation credit notes.
+
+  File: `htdocs/core/class/html.formmargin.class.php`
+  (`FormMargin::getMarginInfosArray()`)
+
+  The sale price of a situation line comes from `facturedet.total_ht`, already
+  prorated by the progress of the situation. The buy price was prorated only
+  when `INVOICE_USE_SITUATION` was exactly `1`, so progress mode compared the
+  sale of one situation against the cost of the whole job: lines already settled
+  at 100 % in an earlier situation weighed 0 € in sale but brought their full
+  cost. The guard dates from v17 (`befdd967f79`); mode 2 arrived in v20 without
+  this call site being updated.
+
+  A single formula covers both modes, because `total_ht` and `situation_percent`
+  share the same semantics within a mode (cumulative in mode 1, delta in
+  mode 2). The ratio uses `abs()`: on a credit-note line the sign is carried by
+  both `subprice` and `situation_percent`, and `$pa_ht` is already sign-flipped
+  above, so a signed ratio flipped the cost back to positive.
+
+  Upstream: still present in `develop`, which kept the `== 1` guard. Pull
+  request to open; drop this patch once it is merged and backported to 23.0.

--- a/htdocs/core/class/html.formmargin.class.php
+++ b/htdocs/core/class/html.formmargin.class.php
@@ -107,18 +107,18 @@ class FormMargin
 			$pa_ht = (($pv < 0 || ($pv == 0 && in_array($object->element, array('facture', 'facture_fourn')) && $object->type == $object::TYPE_CREDIT_NOTE)) ? -$line->pa_ht : $line->pa_ht);
 			'@phan-var-force CommonObject $object';
 
-			if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {	// Special case for old situation mode
+			$pa = $line->qty * $pa_ht;
+
+			$situationmode = getDolGlobalInt('INVOICE_USE_SITUATION');	// 0 = disabled, 1 = cumulative, 2 = progress
+
+			if (($situationmode == 1 || $situationmode == 2) && $object->element == 'facture') {
 				'@phan-var-force Facture $object';
 				/** @var Facture $object */
-				if (($object->element == 'facture' && $object->type == $object::TYPE_SITUATION)
-					|| ($object->element == 'facture' && $object->type == $object::TYPE_CREDIT_NOTE && getDolGlobalInt('INVOICE_USE_SITUATION_CREDIT_NOTE') && $object->situation_counter > 0)) {
-					// We need a compensation relative to $line->situation_percent
-					$pa = $line->qty * $pa_ht * ($line->situation_percent / 100);
-				} else {
-					$pa = $line->qty * $pa_ht;
+				if ($object->type == $object::TYPE_SITUATION
+					|| ($object->type == $object::TYPE_CREDIT_NOTE && getDolGlobalInt('INVOICE_USE_SITUATION_CREDIT_NOTE') && $object->situation_counter > 0)) {
+					// total_ht of a situation line is already prorated by abs(situation_percent); the sign is carried by $pa_ht, so never by the ratio
+					$pa *= abs($line->situation_percent) / 100;
 				}
-			} else {
-				$pa = $line->qty * $pa_ht;
 			}
 
 			// calcul des marges


### PR DESCRIPTION
## Symptom

The **Margins** block of situation invoices shows figures that differ from the current production, although no product or service was changed. The cost price is far above the sale price, giving a heavily negative margin. Seen on several situation invoices, example **FA2608-0529** (id 2344, situation 2/2, cycle 114): margin displayed **−6 646,59** instead of **+1 049,76**.

## Root cause

`FormMargin::getMarginInfosArray()`, in `htdocs/core/class/html.formmargin.class.php`:

```php
if (getDolGlobalInt('INVOICE_USE_SITUATION') == 1) {   // Special case for old situation mode
    ...
        $pa = $line->qty * $pa_ht * ($line->situation_percent / 100);
    } else {
        $pa = $line->qty * $pa_ht;
    }
} else {
    $pa = $line->qty * $pa_ht;      // <-- mode 2 lands here
}
```

The sale price of a situation line comes from `facturedet.total_ht`, which is **already prorated** by the progress of the situation. The buy price was prorated only when `INVOICE_USE_SITUATION` is exactly `1`, so progress mode falls into the `else` and takes **100 % of each line cost**.

The comparison is therefore *the sale of this situation* against *the cost of the whole job*. Lines already settled at 100 % in an earlier situation weigh 0 € in sale on the current situation but bring their full cost, and the product margin sinks.

The `== 1` guard dates from v17 (`befdd967f79`, March 2023). Mode 2 arrived in v20 (June 2024) without this call site being updated. **The bug is still present in `origin/develop`**, which improved the mode 1 computation but kept the same guard.

## Fix

One formula covers both modes, so this **removes a special case instead of adding one** — a single code path, a single multiplication.

Within a mode, `total_ht` and `situation_percent` share the same semantics:

| Mode | `situation_percent` | `total_ht` | Result of the formula |
|---|---|---|---|
| 1 (legacy, cumulative) | cumulative since the start of the cycle | cumulative | cumulative cost, consistent with a cumulative sale |
| 2 (progress, delta) | delta of the period | delta | cost of the period, consistent with the sale of the period |

Verified over the 277 situation invoices of the instance: `total_ht = qty × subprice × situation_percent / 100`.

### Why `abs()`

The ratio is a **magnitude, never a sign**. On a credit-note line the sign is carried twice — `subprice` is negative **and** `situation_percent` is negative — while `buy_price_ht` is stored positive and `$pa_ht` is already sign-flipped a few lines above.

A signed ratio flips the cost back to positive. Measured on **AV2309-0018**: sale −3 362,80 against a cost of **+1 694,00**, margin −5 056,80. With `abs()`: cost −1 694,00, margin −1 668,80, the exact mirror of the credited portion.

This also repairs **mode 1**, where the same defect stood unnoticed. Measured over the 296 objects in the perimeter: **3 change**, all three situation credit notes, each going from a wrong positive cost to the correct negative one. No other object moves.

| Ref | id | cost before | cost after |
|---|---|---|---|
| AV2207-0004 | 131 | +3 282,81 | −3 282,81 |
| AV2207-0006 | 136 | +16 305,22 | −16 305,22 |
| AV2309-0018 | 495 | +1 694,00 | −1 694,00 |

## Verification

Figures below come from calling the real method on the instance, not from a hand computation.

**FA2608-0529 (id 2344, S2/2, cycle 114)**

| | Sale | Cost before | Cost after |
|---|---|---|---|
| Products | 613,60 | 8 061,11 | **364,76** |
| Services | 5 036,92 | 4 236,00 | 4 236,00 |
| **Total margin** | | **−6 646,59** | **+1 049,76** |

The 7 696,35 € of phantom cost came from 6 product lines at 0 % progress on this situation, already settled on situation 1.

**Cycle arithmetic — the check that closes the reasoning**

| | Margin |
|---|---|
| S1 FA2607-0521 | +940,00 |
| S2 FA2608-0529 | +1 049,76 |
| **Sum over the cycle** | **1 989,7641** |

Exactly the total margin reported by the current production (1 989,7641).

**Mirror check** — the 6 product lines at 0 % on S2 carry 100 % of their cost on S1: 200 + 1 219,40 + 3 697,92 + 1 054 + 1 246,46 + 278,57 = **7 696,35**, the phantom cost that previously appeared on S2.

`php -l` passes.

## Scope

- **Display only on this path.** `getMarginInfosArray()` writes nothing. No data to repair, no recomputation to launch — the change takes effect immediately on every existing situation invoice.
- **One indirect write path exists**, worth knowing: `Facture::insert_discount()` stores the result in the created discount line (`$facligne->pa_ht = $arraytmp['pa_total']`). Checked on the instance: all 377 discount lines carry `buy_price_ht = 0`, so nothing was polluted here.
- **Untouched:** standard invoices, deposits, supplier invoices, proposals, orders. The guard keeps the perimeter to situation invoices and, through `INVOICE_USE_SITUATION_CREDIT_NOTE`, to their credit notes.
- **The Margin module reports do not use this method.** `customerMargins.php`, `agentMargins.php`, `productMargins.php` and `tabs/*` carry their own SQL, which already applies `situation_percent / 100` unconditionally — so they were never affected by this bug, and they confirm the prorata is the core rule. They do carry the **same sign defect** on credit notes (signed percent, no `abs`). Same root cause duplicated across 5 files; left out of this pull request.

## Notes for this instance

`INVOICE_USE_SITUATION = 2` on both entities since 11/08/2026 17:02, right after the official `facturesituationmigration` module ran (`FACTURESITUATIONMIGRATION_ISDONE = 1` at 17:01:57). The lines of this base are therefore stored as **delta**, and 271 of the 277 situation invoices verify `sum of lines = invoice total`.

**Reverting `INVOICE_USE_SITUATION` to 1 is not an option.** In any mode other than 2, `CommonObject::update_price()` subtracts the totals of the previous situations; on delta-stored lines that subtraction would corrupt the invoice totals on the first recomputation. Mode 2 is the semantics matching this data.

Unrelated pre-existing data anomaly, flagged for the record: 5 invoices (93, 112, 321, 488, 942 — 2022 to 2024, all validated and paid, all fully credited afterwards) have a correctly prorated header total but line `total_ht` left at 100 %. On those the displayed **sale** price is overstated, independently of this fix.

## Core patch debt

This is a core file, so the patch is overwritten by each core upgrade. It is tracked in the new `ChangeLog_calegari` — the register of core patches to re-apply — until the upstream pull request lands. The bug still exists in `develop`, so a pull request is to be opened at Dolibarr and this patch dropped once it is merged and backported to 23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
