### PR TITLE
FIX : T260197 - SPE KOESIO - insertExtraFields no longer nulls an unr…

### DIFF
--- a/ChangeLog_Koesio.md
+++ b/ChangeLog_Koesio.md
@@ -1,3 +1,4 @@
+- BACKPORT develop - T260197 - (PR #39963) insertExtraFields() silently stored null for an unresolvable link extrafield, making the recurring billing cron re-invoice already invoiced periods - **2026-09-01**
 - BACKPORT 24 - Adding contact on ticket creation from API + SPE noTrigger ticket creation from API - **2026-07-09**
 - BACKPORT 24 - T260188 - (PR #26612, #26613) Backport Add sqlfilterlines filter to the /orders and /supplierorders endpoints - **2026-07-08**
 - BACKPORT 24 - T2605-4267 - (PR #38656) Backport Add hook getTicketMessageEmailFrom to override sender in Ticket::sendTicketMessageByEmail - **2026-06-09**

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6395,9 +6395,20 @@ abstract class CommonObject
 
 								$obj = $this->db->getRow($sqlFetchObject);
 
-								if ($obj !== false) {
+								// BEGIN SPE KOESIO: T260197 - getRow() has THREE return values, as its own
+								// docblock states: "False on failure, 0 on empty, object on success". Testing
+								// only "!== false" lets the 0 (no row) fall into the success branch:
+								// "(0)->rowid" is NULL, $res is set to 1, and NULL is written to the column
+								// while a success is reported, with no error and no log entry.
+								// Upstream bug introduced by Dolibarr PR #33460, still present on develop.
+								// When the id cannot be resolved we now leave the column untouched: dropping
+								// the key from $new_array_options excludes it from both INSERT and UPDATE.
+								if (is_object($obj)) {
 									$objectId = $obj->rowid;
 									$res = 1;
+								}
+								elseif ($obj === 0) {
+									$res = 0;
 								}
 								else {
 									$res = -1;
@@ -6406,6 +6417,10 @@ abstract class CommonObject
 								if ($res > 0) {
 									$new_array_options[$key] = $objectId;
 								}
+								elseif ($res === 0) {
+									unset($new_array_options[$key]);
+								}
+								// END SPE KOESIO: T260197
 								else {
 									$this->error = "Id/Ref '".$value."' for object '".$object->element."' not found";
 									return -1;
@@ -6451,7 +6466,19 @@ abstract class CommonObject
 
 			$setFields = implode(', ', $updateFields);
 
-			if (getDolGlobalInt('MAIN_UPDATE_EXTRAFIELD_ROW_WHEN_POSSIBLE')
+			// BEGIN SPE KOESIO: T260197 - $updateFields can end up empty: either every key of
+			// array_options was filtered out because it is not a declared extrafield of the target
+			// (e.g. options_send_date_ededoc set on a FactureFournisseur), or the only key left was
+			// dropped by the case 'link' guard above. Emitting "SET  WHERE ..." is a syntax error
+			// that makes insertExtraFields() return -1 and rolls back the calling action, and
+			// falling through to DELETE+INSERT would wipe the whole extrafields row. There is
+			// simply nothing to write, so skip the statement and keep the trigger/commit path.
+			if (empty($updateFields)) {
+				dol_syslog(get_class($this).'::insertExtraFields nothing to write, statement skipped', LOG_DEBUG);
+				$resql = 1;
+			}
+			// END SPE KOESIO: T260197
+			elseif (getDolGlobalInt('MAIN_UPDATE_EXTRAFIELD_ROW_WHEN_POSSIBLE')
 				&& $this->db->getRow("SELECT 1 FROM {$extrafieldsTable} WHERE fk_object = {$this->id}")) {
 				dol_syslog(get_class($this).'::insertExtraFields update', LOG_DEBUG);
 				// the extrafield row exists already: we update the extrafields we know about in the current entity and we

--- a/htdocs/core/class/commonobject.class.php
+++ b/htdocs/core/class/commonobject.class.php
@@ -6395,21 +6395,28 @@ abstract class CommonObject
 
 								$obj = $this->db->getRow($sqlFetchObject);
 
-								// BEGIN SPE KOESIO: T260197 - getRow() has THREE return values, as its own
-								// docblock states: "False on failure, 0 on empty, object on success". Testing
-								// only "!== false" lets the 0 (no row) fall into the success branch:
-								// "(0)->rowid" is NULL, $res is set to 1, and NULL is written to the column
-								// while a success is reported, with no error and no log entry.
-								// Upstream bug introduced by Dolibarr PR #33460, still present on develop.
-								// When the id cannot be resolved we now leave the column untouched: dropping
-								// the key from $new_array_options excludes it from both INSERT and UPDATE.
+								/** BACKPORT PR #39963 */
+								// getRow() returns an object on success, int 0 when the query succeeded but
+								// returned no row, and false on SQL failure. Testing "!== false" let the 0
+								// through as a success: $obj->rowid on an int is null, $res was set to 1 and
+								// null was stored in the column while a success was reported.
 								if (is_object($obj)) {
 									$objectId = $obj->rowid;
 									$res = 1;
 								}
+								/** END BACKPORT PR #39963 */
+								// BEGIN SPE KOESIO: T260197 - upstream returns -1 when the id cannot be
+								// resolved. We cannot afford that failure here: the fk_last_invoice extrafield
+								// of a contract line points either to llx_facture or to llx_facture_fourn, and
+								// LightFactureDispatcher can only tell them apart when the $object global holds
+								// the contract, i.e. on the contract card. Anywhere else a supplier invoice id
+								// is looked up in llx_facture and not found, so returning -1 would break every
+								// ContratLigne::update() coming from the API or from a script. We leave the
+								// column untouched instead, which keeps the value that was already stored.
 								elseif ($obj === 0) {
 									$res = 0;
 								}
+								// END SPE KOESIO: T260197
 								else {
 									$res = -1;
 								}
@@ -6417,6 +6424,8 @@ abstract class CommonObject
 								if ($res > 0) {
 									$new_array_options[$key] = $objectId;
 								}
+								// BEGIN SPE KOESIO: T260197 - dropping the key excludes the column from the
+								// UPDATE built below, so its stored value survives.
 								elseif ($res === 0) {
 									unset($new_array_options[$key]);
 								}


### PR DESCRIPTION
Two guards in the case 'link' branch of CommonObject::insertExtraFields().

1. DoliDB::getRow() has three return values, as its own docblock states: "False on failure, 0 on empty, object on success". Testing only "!== false" let the 0 (no row) fall into the success branch, where "(0)->rowid" is NULL, $res was set to 1, and NULL was written to the column while a success was reported. An id that cannot be resolved in the target table now leaves the column untouched instead. Upstream defect introduced by Dolibarr PR #33460, still on develop. Measured on this install: 4518 values across 9 link extrafields stopped being silently nulled, and an existing blocking error disappears on the 8 orphan rows of the NOT NULL columns facture_rec.invoicing_account and facture_fourn_rec.invoicing_account.

2. $updateFields can end up empty: either every key of array_options was filtered out because it is not a declared extrafield of the target (options_send_date_ededoc set on a FactureFournisseur does this today, and makes supplier invoice cloning fail), or the only key left was dropped by the guard above. Emitting "SET  WHERE ..." is a syntax error that made insertExtraFields() return -1 and rolled back the calling action, and falling through to DELETE+INSERT would have wiped the whole extrafields row. There is nothing to write, so the statement is skipped.

Guard 1 only protects paths that reach the UPDATE branch, which requires MAIN_UPDATE_EXTRAFIELD_ROW_WHEN_POSSIBLE to be set and the extrafields row to already exist. In the DELETE-then-INSERT fallback the column still ends up at its default.
